### PR TITLE
Select multiple grammar errors

### DIFF
--- a/src/app/student-components/dashboard/dashboard.component.css
+++ b/src/app/student-components/dashboard/dashboard.component.css
@@ -268,19 +268,20 @@ border-radius: 5px 5px 5px 5px;
     display: flex;
     width: 90%;
     margin-left: 5%;
-    padding: 5px;
+    padding-top: 2px;
+    padding-left: 5px;
 }
 
 .selectErrorCheckbox {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: space-around;
   text-align: left;
   background-color: #70a87f;
   display: flex;
+  color: white;
   width: 90%;
   margin-left: 5%;
-  padding: 5px;
 }
 
 .selectGrammarFilter {

--- a/src/app/student-components/dashboard/dashboard.component.html
+++ b/src/app/student-components/dashboard/dashboard.component.html
@@ -64,7 +64,7 @@
         <!-- display grammar error filter options -->
         <div class="selectErrorCheckbox" *ngIf="grammarSelected">
           <div *ngFor="let recipient of filteredTags | keyvalue">
-             <div style="padding-left: 2px;padding-right: 2px;" ><input [ngModel]="checkBox.get(recipient.key)" (ngModelChange)="checkBox.set(recipient.key, $event)" type="checkbox"/> {{recipient.key | lowercase}} ({{recipient.value.length}})</div> 
+             <div style="margin:2px;" ><input [ngModel]="checkBox.get(recipient.key)" (ngModelChange)="checkBox.set(recipient.key, $event)" type="checkbox"/> {{recipient.key | lowercase}} ({{recipient.value.length}})</div> 
           </div>
         </div>
         <!-- display the story with error highlighting-->
@@ -72,11 +72,7 @@
           <textarea mwlTextInputElement class="textField textFieldGrammarCheck" [(ngModel)]="story.text" (input)="storyEdited()" #inputTextarea readonly></textarea>
           <!-- an gramadoir -->
           <div *ngIf="grammarSelected">
-            <div *ngFor="let recipient of filteredTags | keyvalue">
-              <div *ngIf="checkBox.get(recipient.key)">
-                <mwl-text-input-highlight [tags]="recipient.value" [textInputElement]="inputTextarea" (tagClick)="chooseGrammarTag($event.tag)" (tagMouseEnter)="addTagHoverClass($event.target)" (tagMouseLeave)="removeTagHoverClass($event.target)"></mwl-text-input-highlight>
-              </div>
-            </div>
+                <mwl-text-input-highlight [tags]="getSelectedTags()" [textInputElement]="inputTextarea" (tagClick)="chooseGrammarTag($event.tag)" (tagMouseEnter)="addTagHoverClass($event.target)" (tagMouseLeave)="removeTagHoverClass($event.target)"></mwl-text-input-highlight>
           </div>
           <!-- broad/slender -->
           <div *ngIf="!grammarSelected">

--- a/src/app/student-components/dashboard/dashboard.component.ts
+++ b/src/app/student-components/dashboard/dashboard.component.ts
@@ -308,6 +308,18 @@ export class DashboardComponent implements OnInit {
     });
   }
 
+  getSelectedTags(): HighlightTag[] {
+    const selectedTagsLists = Array.from(this.filteredTags.entries()).map(entry => {
+      if (this.checkBox.get(entry[0])) {
+        return entry[1];
+      } else {
+        return [];
+      }
+    });
+    const selectedTags = selectedTagsLists.reduce((acc, val) => acc.concat(val), []);
+    return selectedTags;
+  }
+
 /*
 * Update the grammar error map of the stat object corresponding to the current student id
 */

--- a/src/app/student-components/dashboard/dashboard.component.ts
+++ b/src/app/student-components/dashboard/dashboard.component.ts
@@ -308,14 +308,24 @@ export class DashboardComponent implements OnInit {
     });
   }
 
+  /**
+   * Gets an array of HighlighTags for which the associated grammar error category
+   * is selected according to the checkBox map.
+   * 
+   * E.g. if 'seimhiu' checkbox is selected, then this will return the array of
+   * HighlightTags for seimhiu.
+   */
   getSelectedTags(): HighlightTag[] {
+    // Get only those filteredTags whose keys map to true in checkBox
     const selectedTagsLists = Array.from(this.filteredTags.entries()).map(entry => {
+      // entry[0] is key, entry[1] is val.
       if (this.checkBox.get(entry[0])) {
         return entry[1];
       } else {
         return [];
       }
     });
+    // Flatten 2d array of HighlightTags
     const selectedTags = selectedTagsLists.reduce((acc, val) => acc.concat(val), []);
     return selectedTags;
   }


### PR DESCRIPTION
- Multiple grammar error categories can now be selected at the same time in the gramadóir interface.
- Made the text indicating the grammar error categories white for legibility.

i.e.
![image](https://user-images.githubusercontent.com/34962541/108638393-f2a0db80-7486-11eb-9481-f416bcc9c682.png)
