### PR TITLE
Fixed story history button

### DIFF
--- a/src/app/admin-components/story/story.component.html
+++ b/src/app/admin-components/story/story.component.html
@@ -3,7 +3,7 @@
       <div class="storyTextContainer">
         <div class="storyTextHeader">{{ts.l.text}}</div>
         <div class="storyText">{{story?.text}}</div>
-        <button class="greenBtn" (click)="goToStoryHistory()">{{ts.l.story_history}}y</button>
+        <button class="greenBtn" (click)="goToStoryHistory()">{{ts.l.story_history}}</button>
       </div>
       <div class="storyInfoContainer">
           <div class="storyTextHeader">{{ts.l.information}}</div>

--- a/src/app/translation.json
+++ b/src/app/translation.json
@@ -212,6 +212,7 @@
             "ISODate" : "ISODate",
             "story_id" : "Story id",
             "story_text" : "Story text",
+            "story_history" : "Story History",
             
             "messages" : "Messages",
             "new_message" : "New Message",
@@ -588,6 +589,7 @@
             "ISODate" : "Dáta ISO",
             "story_id" : "Comhartha aitheantais an scéil",
             "story_text" : "Téacs an scéil",
+            "story_history" : "Story History",
             
             "messages" : "Teachtaireachtaí",
             "new_message" : "Teachtaireacht Nua",


### PR DESCRIPTION
Got rid of the 'y' and replaced with 'story history' on the admin panel.  Still needs an Irish translation.
<img width="845" alt="Captura de Pantalla 2021-02-23 a la(s) 20 05 25" src="https://user-images.githubusercontent.com/13711456/108901297-9d91d080-7612-11eb-8eec-ab7f51e72e96.png">
