### PR TITLE
Recording sessions + archiving

### DIFF
--- a/api/models/story.js
+++ b/api/models/story.js
@@ -33,6 +33,9 @@ let Story = new Schema({
         audioId: {
             type: String
         }
+    },
+    activeRecording: {
+        type: String
     }
 }, {
     collection: 'story'

--- a/api/routes/recording.route.js
+++ b/api/routes/recording.route.js
@@ -24,7 +24,6 @@ MongoClient.connect('mongodb://localhost:27017', (err, client) => {
 
 recordingRoutes.route('/create').post((req, res) => {
     const recording = new VoiceRecording(req.body);
-    console.log('Recording:', recording);
     recording.save().then(_ => {
         res.status(200).json({"message" : "Recording created successfully", "recording": recording});
     }).catch(err => {
@@ -41,6 +40,34 @@ recordingRoutes.route('/:id').get(function(req, res) {
         }
     });
 });
+
+// Update the audio ids and indices for a given recording
+recordingRoutes.route('/updateTracks/:id').post(function (req, res) {
+    VoiceRecording.findById(req.params.id, function(err, recording) {
+        if(err) res.json(err);
+        if(recording) {
+            
+            if(req.body.paragraphAudioIds) {
+                recording.paragraphAudioIds = req.body.paragraphAudioIds;
+            }
+            if(req.body.paragraphIndices) {
+                recording.paragraphIndices = req.body.paragraphIndices;
+            }
+            if(req.body.sentenceAudioIds) {
+                recording.sentenceAudioIds = req.body.sentenceAudioIds;
+            }
+            if(req.body.sentenceIndices) {
+                recording.sentenceIndices = req.body.sentenceIndices;
+            }
+            
+            recording.save().then(_ => {
+                res.json('Update complete');
+            }).catch(_ => {
+                res.status(400).send("Unable to update");
+            });
+        }
+    });
+})
 
 recordingRoutes.route('/saveAudio/:storyId/:index/:uuid').post((req, res) => {
     const storage = multer.memoryStorage();

--- a/api/routes/story.route.js
+++ b/api/routes/story.route.js
@@ -239,7 +239,26 @@ storyRoutes.route('/addFeedbackAudio/:id').post((req, res) => {
             res.status(404).json({"message" : "Story does not exist"});
         }
     });
-    
+});
+
+storyRoutes.route('/updateActiveRecording/:id').post((req, res) => {
+    console.log('Ran');
+    Story.findById(req.params.id, (err, story) => {
+        console.log('Found');
+        if (err) res.json(err);
+        if(story) {
+            if (req.body.activeRecording) {
+                story.activeRecording = req.body.activeRecording;
+            }
+            story.save().then(_ => {
+                res.json('Update complete');
+            }).catch(_ => {
+                res.status(400).send("Unable to update");
+            });
+        } else {
+            res.status(404).json({message: 'Story not found'});
+        }
+    });
 });
 
 /*
@@ -248,60 +267,11 @@ storyRoutes.route('/addFeedbackAudio/:id').post((req, res) => {
 storyRoutes.route('/synthesise/:id').get((req, res) => {
     Story.findById(req.params.id, (err, story) => {
         if(story) {
-            let dialectCode;
-            if(story.dialect === 'connemara') dialectCode = 'ga_CM';
-            if(story.dialect === 'donegal') dialectCode = 'ga_GD';
-            if(story.dialect === 'kerry') dialectCode = 'ga_MU';
-
-            // create a form with the story text, dialect choice, html, and speed
-            let form = {
-                Input: story.text,
-                Locale: dialectCode,
-                Format: 'html',
-                Speed: '1',
-            };
-            
-            // turn form into a url query string
-            let formData = querystring.stringify(form);
-            let contentLength = formData.length;
-            
-            // make a request to abair passing in the form data
-            request({
-                headers: {
-                'Host' : 'www.abair.tcd.ie',
-                'Content-Length': contentLength,
-                'Content-Type': 'application/x-www-form-urlencoded',
-                },
-                uri: 'https://www.abair.tcd.ie/webreader/synthesis',
-                body: formData,
-                method: 'POST'
-            }, function (err, resp, body) {
-                if(err) res.send(err);
-                if(body) {
-                    console.log(body);
-                    // audioContainer is chunk of text made up of paragraphs
-                    let audioContainer = parse(body).querySelectorAll('.audio_paragraph');
-                    let paragraphs = [];
-                    let urls = [];
-                    // loop through every paragraph and fill array of sentences
-                    for(let p of audioContainer) {
-                        let sentences = [];
-                        for(let s of p.childNodes) {
-                            // push the sentences
-                            if(s.tagName === 'span') {
-                                sentences.push(s.toString());
-                            } 
-                            // push the audio ids for the sentences
-                            else if(s.tagName === 'audio') {
-                                urls.push(s.id);
-                            }
-                        }
-                        paragraphs.push(sentences);
-                    }
-                    console.log('Paragraphs', paragraphs);
-                    res.json({ html : paragraphs, audio : urls });
+            synthesiseStory(story).then(synthesis => {
+                if (synthesis) {
+                    res.json(synthesis);
                 } else {
-                    res.json({status: '404', message: 'No response from synthesiser'});
+                    res.json({message: 'Synthesis failed :('});
                 }
             });
         } else {
@@ -309,6 +279,85 @@ storyRoutes.route('/synthesise/:id').get((req, res) => {
         }
     });
 });
+
+
+/*
+* Synthesise a story object given in req.body
+*/
+storyRoutes.route('/synthesiseObject/').post((req, res) => {
+    if (req.body.story) {
+        synthesiseStory(req.body.story).then(synthesis => {
+            if (synthesis) {
+                res.json(synthesis);
+            } else {
+                res.json({message: 'Synthesis failed :('});
+            }
+        });
+    } else {
+        res.status(400).json({message: 'Story object must be provided in body.'});
+    }
+});
+
+function synthesiseStory(story) {
+    let dialectCode;
+    if(story.dialect === 'connemara') dialectCode = 'ga_CM';
+    if(story.dialect === 'donegal') dialectCode = 'ga_GD';
+    if(story.dialect === 'kerry') dialectCode = 'ga_MU';
+
+    // create a form with the story text, dialect choice, html, and speed
+    let form = {
+        Input: story.text,
+        Locale: dialectCode,
+        Format: 'html',
+        Speed: '1',
+    };
+    
+    // turn form into a url query string
+    let formData = querystring.stringify(form);
+    let contentLength = formData.length;
+
+    return new Promise((resolve, reject) => {
+        // make a request to abair passing in the form data
+        request({
+            headers: {
+            'Host' : 'www.abair.tcd.ie',
+            'Content-Length': contentLength,
+            'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            uri: 'https://www.abair.tcd.ie/webreader/synthesis',
+            body: formData,
+            method: 'POST'
+        }, function (err, resp, body) {
+            if(err) res.send(err);
+            if(body) {
+                // audioContainer is chunk of text made up of paragraphs
+                let audioContainer = parse(body).querySelectorAll('.audio_paragraph');
+                let paragraphs = [];
+                let urls = [];
+                // loop through every paragraph and fill array of sentences
+                for(let p of audioContainer) {
+                    let sentences = [];
+                    for(let s of p.childNodes) {
+                        // push the sentences
+                        // s.rawTagName <--> s.tagName if synthesis text not appearing
+                        if(s.rawTagName === 'span') {
+                            sentences.push(s.toString());
+                        } 
+                        // push the audio ids for the sentences
+                        // s.rawTagName <--> s.tagName if synthesis text not appearing
+                        else if(s.rawTagName === 'audio') {
+                            urls.push(s.id);
+                        }
+                    }
+                    paragraphs.push(sentences);
+                }
+                resolve({html : paragraphs, audio : urls });
+            } else {
+                reject();
+            }
+        });
+    });
+}
 
 storyRoutes.route('/gramadoir/:id/:lang').get((req, res) => {
     Story.findById(req.params.id, (err, story) => {

--- a/src/app/recording.service.ts
+++ b/src/app/recording.service.ts
@@ -26,6 +26,10 @@ export class RecordingService {
     return this.http.post(this.baseUrl + "create/", recording);
   }
 
+  update(recordingId: string, trackData: Object) : Observable<any> {
+    return this.http.post(this.baseUrl + "updateTracks/" + recordingId + "/", trackData);
+  }
+
   saveAudio(storyId, audioBlob: Blob, index: string) : Observable<any> {
     const formData = new FormData();
     formData.append('audio', audioBlob);

--- a/src/app/recording.ts
+++ b/src/app/recording.ts
@@ -9,7 +9,7 @@ export class Recording {
     sentenceAudioIds: string[];
     sentenceIndices: number[];
 
-    constructor(paragraphAudioIds, paragraphIndices, sentenceAudioIds, sentenceIndices, story) {
+    constructor(story, paragraphAudioIds=[], paragraphIndices=[], sentenceAudioIds=[], sentenceIndices=[]) {
         this.paragraphAudioIds = paragraphAudioIds;
         this.paragraphIndices = paragraphIndices;
         this.sentenceAudioIds = sentenceAudioIds;

--- a/src/app/story.service.ts
+++ b/src/app/story.service.ts
@@ -32,7 +32,8 @@ export class StoryService {
       dialect: dialect,
       text: text,
       author: author,
-      lastUpdated: new Date()
+      lastUpdated: new Date(),
+      activeRecording: null
     };
     console.log(storyObj);
     this.http.post(this.baseUrl + 'create', storyObj)
@@ -103,7 +104,11 @@ export class StoryService {
     return this.http.get(this.baseUrl + 'gramadoir/' + id + '/' + this.ts.l.iso_code);
   }
   
-  synthesiseRecording(id: string) : Observable<any> {
-    return this.http.get(this.baseUrl + 'synthesiseRecording/' + id);
+  synthesiseObject(storyObject: Story) : Observable<any> {
+    return this.http.post(this.baseUrl + 'synthesiseObject/', {story: storyObject});
+  }
+
+  updateActiveRecording(storyId: string, recordingId: string): Observable<any> {
+    return this.http.post(this.baseUrl + 'updateActiveRecording/' + storyId + '/', {activeRecording: recordingId});
   }
 }

--- a/src/app/story.ts
+++ b/src/app/story.ts
@@ -12,4 +12,5 @@ export class Story {
         text: string;
         audioId: string;
     };
+    activeRecording: string;
 }

--- a/src/app/student-components/recording/recording.component.html
+++ b/src/app/student-components/recording/recording.component.html
@@ -19,6 +19,9 @@
         <div></div>
         <div [ngClass]="recordingMode ? 'bookTitle': 'bookTitleHistory'">{{story?.title}}<span *ngIf="!recordingSaved">*</span></div>
         <div *ngIf="recordingMode" class="recordingSaveIcon">
+          <div class="recordingUnsavedIcon" (click)="saveRecordings(); archive(story)">
+            Archive
+          </div>
           <div *ngIf="recordingSaved" class="recordingSavedIcon">
             {{ts.l.saved}} <i class="fas fa-check"></i>
           </div>

--- a/src/app/student-components/recording/recording.component.html
+++ b/src/app/student-components/recording/recording.component.html
@@ -19,7 +19,7 @@
         <div></div>
         <div [ngClass]="recordingMode ? 'bookTitle': 'bookTitleHistory'">{{story?.title}}<span *ngIf="!recordingSaved">*</span></div>
         <div *ngIf="recordingMode" class="recordingSaveIcon">
-          <div class="recordingUnsavedIcon" (click)="saveRecordings(); archive(story)">
+          <div class="recordingUnsavedIcon" (click)="archive(story)">
             Archive
           </div>
           <div *ngIf="recordingSaved" class="recordingSavedIcon">

--- a/src/app/student-components/recording/recording.component.ts
+++ b/src/app/student-components/recording/recording.component.ts
@@ -7,6 +7,7 @@ import { ActivatedRoute, Router, NavigationEnd, NavigationStart } from '@angular
 import { DomSanitizer, SafeUrl, SafeHtml } from '@angular/platform-browser';
 import { Story } from '../../story';
 import { Recording } from '../../recording';
+import { NullInjector } from '@angular/core/src/di/injector';
 declare var MediaRecorder : any;
 
 @Component({
@@ -82,18 +83,60 @@ export class RecordingComponent implements OnInit {
         this.storyService.getStory(params['id']).subscribe(
           story => {
             this.story = story;
-            this.synthesiseStory(story._id);
-          }
-        );
+            if (this.story.activeRecording) {
+              this.recordingService.get(this.story.activeRecording).subscribe(recording => {
+                this.synthesiseStory(recording.storyData);
+                this.loadAudio(recording);
+              });
+            } else {
+              console.log('This should be running');
+              this.synthesiseStory(this.story);
+              this.archive(this.story);
+            }
+          });
+      });
+    }
+
+    archive(story: Story) {
+      const newActiveRecording = new Recording(story);
+      this.recordingService.create(newActiveRecording).subscribe(res => {
+        if (res.recording) {
+          const newActiveRecordingId = res.recording._id;
+          console.log(newActiveRecordingId);
+          this.storyService.updateActiveRecording(story._id, newActiveRecordingId).subscribe(_ => {
+            this.story.activeRecording = newActiveRecordingId;
+            // Reset all recording / audio data
+            this.paragraphs = [];
+            this.sentences = [];
+            this.paragraphAudioSources = [];
+            this.paragraphChunks = [];
+            this.sentenceAudioSources = [];
+            this.sentenceChunks = [];
+            // Resynthesise with latest story text
+            this.getStory();
+          });
+        }
       })
+    }
+
+    loadAudio(recording: Recording) {
+      for (let i=0; i<recording.paragraphIndices.length; ++i) {
+        this.recordingService.getAudio(recording.paragraphAudioIds[i]).subscribe((res) => {
+          this.paragraphAudioSources[recording.paragraphIndices[i]] = this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(res));
+        });
+      }
+      for (let i=0; i<recording.sentenceIndices.length; ++i) {
+        this.recordingService.getAudio(recording.sentenceAudioIds[i]).subscribe((res) => {
+          this.sentenceAudioSources[recording.sentenceIndices[i]] = this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(res));
+        });
+      }
     }
   
   /*
   * Synthesise recording text using story service
   */
-    synthesiseStory(storyId) {
-      console.log('storyId:', storyId);
-      this.storyService.synthesise(storyId).subscribe((res) => {
+    synthesiseStory(story) {
+      this.storyService.synthesiseObject(story).subscribe((res) => {
         // loop through the html of the synthesis response and create sentences/paragraph instances
         for(let p of res.html) {
           let paragraphStr: string = "";
@@ -317,37 +360,37 @@ export class RecordingComponent implements OnInit {
         const blob = new Blob(chunks, {type: 'audio/mp3'});
         return this.recordingService.saveAudio(this.story._id, blob, index).toPromise();
       });
-      
-      console.log("p promises", paragraph_promises);
  
       const sentence_promises = Object.entries(this.sentenceChunks).map(async ([index, chunks]) => {
         const blob = new Blob(chunks, {type: 'audio/mp3'});
         return this.recordingService.saveAudio(this.story._id, blob, index).toPromise();
       });
-      
-      console.log("s promises", sentence_promises);
  
       const paragraphResponses = await Promise.all(paragraph_promises);
       const sentenceResponses = await Promise.all(sentence_promises);
-      
-      console.log("promis.all gone through");
  
       let paragraphIndices = [];
-      let paragraphAudio = [];
+      let paragraphAudioIds = [];
       for (const res of paragraphResponses) {
         paragraphIndices.push(res.index);
-        paragraphAudio.push(res.fileId);
+        paragraphAudioIds.push(res.fileId);
       }
  
       let sentenceIndices = [];
-      let sentenceAudio = [];
+      let sentenceAudioIds = [];
       for (const res of sentenceResponses) {
         sentenceIndices.push(res.index);
-        sentenceAudio.push(res.fileId);
+        sentenceAudioIds.push(res.fileId);
       }
  
-      const recording = new Recording(paragraphAudio, paragraphIndices, sentenceAudio, sentenceIndices, this.story);
-      this.recordingService.create(recording).subscribe(res => {console.log(':)', res)});
+      const trackData = {
+        paragraphAudioIds: paragraphAudioIds,
+        paragraphIndices: paragraphIndices,
+        sentenceIndices: sentenceIndices,
+        sentenceAudioIds: sentenceAudioIds
+      }
+
+      this.recordingService.update(this.story.activeRecording, trackData).subscribe(res => {console.log('Updated :)', res)});
     }
   
   goToHistory() {

--- a/src/app/student-components/recording/recording.component.ts
+++ b/src/app/student-components/recording/recording.component.ts
@@ -77,6 +77,11 @@ export class RecordingComponent implements OnInit {
       this.getStory();
     }
     
+    /**
+     * - Get story from URL id
+     * - Load activeRecording if there is one,
+     * - Otherwise, make a new one, using this.archive()
+     */
     getStory() {
       this.story = null;
       this.route.params.subscribe(params => {
@@ -97,6 +102,12 @@ export class RecordingComponent implements OnInit {
       });
     }
 
+    /**
+     * Archives story.activeRecording by making a new, blank
+     * up-to-date activeRecording for story.
+     * 
+     * @param story - story whose activeRecording will be updated
+     */
     archive(story: Story) {
       const newActiveRecording = new Recording(story);
       this.recordingService.create(newActiveRecording).subscribe(res => {
@@ -119,6 +130,12 @@ export class RecordingComponent implements OnInit {
       })
     }
 
+    /**
+     * Given some recording, gets audio data from the DB and saves it
+     * in SafeUrl arrays to be displayed in <audio>s on the .html page
+     * 
+     * @param recording - recording whose audio clips should be loaded
+     */
     loadAudio(recording: Recording) {
       for (let i=0; i<recording.paragraphIndices.length; ++i) {
         this.recordingService.getAudio(recording.paragraphAudioIds[i]).subscribe((res) => {

--- a/src/app/student-components/view-recording/view-recording.component.ts
+++ b/src/app/student-components/view-recording/view-recording.component.ts
@@ -36,13 +36,14 @@ export class ViewRecordingComponent implements OnInit {
     this.route.params.subscribe(params => {
       this.recordingService.get(params['id']).subscribe((res: Recording) => {
         this.story = res.storyData;
-        this.synthesiseStory(this.story._id);
+        this.synthesiseStory(this.story);
         this.loadRecordings(res);
       });
     })
   }
 
   loadRecordings(recording: Recording) {
+    console.log('The recording!', recording);
     for (let i=0; i<recording.paragraphIndices.length; ++i) {
       this.recordingService.getAudio(recording.paragraphAudioIds[i]).subscribe((res) => {
         this.paragraphToAudioSource[recording.paragraphIndices[i]] = this.sanitizer.bypassSecurityTrustUrl(URL.createObjectURL(res));
@@ -56,9 +57,8 @@ export class ViewRecordingComponent implements OnInit {
     this.recordingsFinishedLoading = true;
   }
 
-  synthesiseStory(storyId) {
-    console.log('storyId:', storyId);
-    this.storyService.synthesise(storyId).subscribe((res) => {
+  synthesiseStory(story) {
+    this.storyService.synthesiseObject(story).subscribe((res) => {
       // loop through the html of the synthesis response and create sentences/paragraph instances
       for(let p of res.html) {
         let paragraphStr: string = "";


### PR DESCRIPTION
**Summary**:
- Added ability to maintain a 'current recording session' for each story, which can be archived to become part of read-only recording history.
- Mechanics all seem to work, although **plenty more to be done in terms of CSS work** and **general testing / looking for bugs**.

**Code-wise, main additions are:**
- `archive()` and `loadAudio()` functions in `recordings.ts`.
- Synthesis code was removed from specific endpoint in `story.routes` and packaged in `synthesiseStory()` function so that it can instead be called by multiple endpoints. Now have both `/synthesise/:id` and `synthesiseObject/` endpoints, latter of which synthesises a story object sent in the `req.body`.
- Added endpoint for updating recording audio ids.
- Added `activeRecording` attribute to story schema.