### PR TITLE
Updated CSS for recoding history

### DIFF
--- a/src/app/student-components/recording-history/recording-history.component.css
+++ b/src/app/student-components/recording-history/recording-history.component.css
@@ -14,8 +14,7 @@
 
 .bookTitle {
     color: #261500;
-    padding-left: 5%;
-    padding-right: 5%;
+    padding-right: 30px;
     display: inline-block;
     font-size: 18pt;
 }
@@ -23,12 +22,11 @@
 
 .myStoriesBtn {
     display: inline;
+    float: left;
     border-style: none;
     color: #261500;
-    width: 100px;
     font-size: 12pt;
     padding-top: 10px;
-    padding-left: 5%;
 }
 
 .myStoriesBtn:hover {
@@ -55,7 +53,7 @@ border-radius: 5px 5px 5px 5px;
 }
 
 .contentsLinkContainer {
-    height: 260px;
+    height: 300px;
     overflow: scroll;
     padding: 10px;
     -webkit-box-shadow: inset 0px 0px 12px 0px rgba(0,0,0,0.5);

--- a/src/app/student-components/recording-history/recording-history.component.html
+++ b/src/app/student-components/recording-history/recording-history.component.html
@@ -2,8 +2,8 @@
 <img src="assets/img/book.png" class="bookImg">
 <div class="bookContentsContainer">
   <div class="contentsContainer">
-    <div (click)="goToDashboard()" class="myStoriesBtn"><i class="fa fa-chevron-left"></i> {{ts.l.story}}</div> 
-    <div class="bookTitle">Recording History</div>
+    <div (click)="goToDashboard()" class="myStoriesBtn"><i class="fa fa-chevron-left"></i> {{ts.l.back}}</div> 
+    <div class="bookTitle">Recordings Archive</div>
     <div class="contentsTitleContainer">
       <div class="contentsLinkTitle">Recording</div>
       <div class="contentsDateTitle">{{ts.l.date}}</div>


### PR DESCRIPTION
- Small update to CSS for recording history (recording archive?) page.
- Now looks like:
<img width="1264" alt="Screenshot 2021-03-09 at 20 14 45" src="https://user-images.githubusercontent.com/34962541/110532175-6cd29080-8114-11eb-8fa7-cf0f89791fe4.png">
