### PR TITLE
Fixed lost recordings

### DIFF
--- a/api/routes/recording.route.js
+++ b/api/routes/recording.route.js
@@ -47,15 +47,15 @@ recordingRoutes.route('/updateTracks/:id').post(function (req, res) {
         if(err) res.json(err);
         if(recording) {
           
-          let bucket = new mongodb.GridFSBucket(db, {
-                  bucketName: 'voiceRecording'
-              });
+            let bucket = new mongodb.GridFSBucket(db, {
+                bucketName: 'voiceRecording'
+            });
             
-              console.log("Request Paragraph audio ids: ", req.body.paragraphAudioIds);
-              console.log("Request Paragraph indices: ", req.body.paragraphIndices);
-              
-              console.log("\nStored Paragraph audio ids: ", recording.paragraphAudioIds);
-              console.log("Stored Paragraph indices: ", recording.paragraphIndices);
+            console.log("Request Paragraph audio ids: ", req.body.paragraphAudioIds);
+            console.log("Request Paragraph indices: ", req.body.paragraphIndices);
+            
+            console.log("\nStored Paragraph audio ids: ", recording.paragraphAudioIds);
+            console.log("Stored Paragraph indices: ", recording.paragraphIndices);
           
             
             if(req.body.paragraphAudioIds) {

--- a/src/app/student-components/recording/recording.component.html
+++ b/src/app/student-components/recording/recording.component.html
@@ -52,13 +52,13 @@
                           <button *ngIf="!p.audioPlaying" (click)="playAudio(p)" class="playAudioBtn"><i class="fa fa-play"></i></button>
                           <!-- Recording button -->
                           <button *ngIf="!isRecordingParagraph[p.index]" class="recordingBtn" (click)="recordAudio(p.index, paragraphChunks, isRecordingParagraph)"><i class="fas fa-microphone"></i></button>
-                          <button *ngIf="isRecordingParagraph[p.index]" class="notRecordingBtn blink" (click)="stopRecording(p.index, paragraphAudioSources, paragraphChunks, isRecordingParagraph);"><i class="fas fa-stop-circle"></i></button>
+                          <button *ngIf="isRecordingParagraph[p.index]" class="notRecordingBtn blink" (click)="stopRecording(p.index, paragraphAudioSources, paragraphChunks, paragraphBlobs, isRecordingParagraph);"><i class="fas fa-stop-circle"></i></button>
                         </div>
                         <hr class="dividerLine" *ngIf="paragraphAudioSources[p.index]">
                         <!-- Audio player -->
                         <div class="cardFooter" *ngIf="paragraphAudioSources[p.index]">
                           <audio *ngIf="paragraphAudioSources[p.index]" [attr.src]="paragraphAudioSources[p.index]" controls #audioTag class="audioPlayer"></audio>
-                          <button *ngIf="paragraphAudioSources[p.index]" class="notRecordingBtn trashBtn" (click)="deleteRecording(p.index, paragraphAudioSources, paragraphChunks)"><i class="fas fa-trash-alt"></i></button>
+                          <button *ngIf="paragraphAudioSources[p.index]" class="notRecordingBtn trashBtn" (click)="deleteRecording(p.index, paragraphAudioSources, paragraphChunks, paragraphBlobs)"><i class="fas fa-trash-alt"></i></button>
                           <div *ngIf="registrationError" class="errorMessage">{{errorText}}</div>
                         </div>
                         </div>
@@ -75,14 +75,14 @@
                             <button *ngIf="!s.audioPlaying" (click)="playAudio(s)" class="playAudioBtn"><i class="fa fa-play"></i></button>
                             <!-- Recording button -->
                             <button *ngIf="!isRecordingSentence[s.index]" class="recordingBtn" type="button" (click)="recordAudio(s.index, sentenceChunks, isRecordingSentence)"><i class="fas fa-microphone"></i></button>
-                            <button *ngIf="isRecordingSentence[s.index]" class="notRecordingBtn blink" (click)="stopRecording(s.index, sentenceAudioSources, sentenceChunks, isRecordingSentence);"><i class="fas fa-stop-circle"></i></button>          
+                            <button *ngIf="isRecordingSentence[s.index]" class="notRecordingBtn blink" (click)="stopRecording(s.index, sentenceAudioSources, sentenceChunks, sentenceBlobs, isRecordingSentence);"><i class="fas fa-stop-circle"></i></button>          
                           </div>
                             
                           <hr class="dividerLine" *ngIf="sentenceAudioSources[s.index]">
                           <!-- Audio player -->
                           <div class="cardFooter" *ngIf="sentenceAudioSources[s.index]">
                             <audio *ngIf="sentenceAudioSources[s.index]" [attr.src]="sentenceAudioSources[s.index]" id="audio" controls #audioTag class="audioPlayer"></audio>
-                            <button *ngIf="sentenceAudioSources[s.index]" class="notRecordingBtn trashBtn" (click)="deleteRecording(s.index, sentenceAudioSources, sentenceChunks)"><i class="fas fa-trash-alt"></i></button>
+                            <button *ngIf="sentenceAudioSources[s.index]" class="notRecordingBtn trashBtn" (click)="deleteRecording(s.index, sentenceAudioSources, sentenceChunks, sentenceBlobs)"><i class="fas fa-trash-alt"></i></button>
                             <div *ngIf="registrationError" class="errorMessage">{{errorText}}</div>
                           </div>
                         </div>     


### PR DESCRIPTION
**Bug description**
- Recordings that weren't recording in the current session were disappearing such that only recordings made in the current session would actually be saved.
- The endpoint for saving recordings simply sets `paragraphAudioIds`, `paragraphIndices`, etc. to the values sent in the request, which only contained the newly recorded audio.
- The issue was that the paragraph audio ids and indices being sent in the request were only the newly recorded ones -- they didn't include the audio that had been loaded from the DB in the first place, which comes in the form of blobs.

**Solution**
- In addition to arrays of chunks, store arrays of blobs for sentences and paragraphs. When audio is loaded from DB, it is put into these blob arrays straight away.
- Any new audios / audio deletion updates are reflected in these blob arrays. The blob arrays reflect exactly the recordings that are visible on the screen.
- When `saveRecordings()` is called now, it saves the blob arrays themselves rather than the chunk arrays. This way the loaded audio is saved along with the new audio / any deletions.

- **Note:** it's important that we get audio deletion working or DB will be wasting memory.