### PR TITLE
Synthesis Refactor

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -59,6 +59,7 @@ import { TeamComponent } from './team/team.component';
 import { AboutLaraComponent } from './about-lara/about-lara.component';
 import { RecordingHistoryComponent } from './student-components/recording-history/recording-history.component';
 import { ViewRecordingComponent } from './student-components/view-recording/view-recording.component';
+import { SafeHtmlPipe } from './pipes/safe-html.pipe';
 
 
 
@@ -103,7 +104,8 @@ import { ViewRecordingComponent } from './student-components/view-recording/view
     TeamComponent,
     AboutLaraComponent,
     RecordingHistoryComponent,
-    ViewRecordingComponent
+    ViewRecordingComponent,
+    SafeHtmlPipe
   ],
   imports: [
     BrowserModule,

--- a/src/app/pipes/safe-html.pipe.spec.ts
+++ b/src/app/pipes/safe-html.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { SafeHtmlPipe } from './safe-html.pipe';
+
+describe('SafeHtmlPipe', () => {
+  it('create an instance', () => {
+    const pipe = new SafeHtmlPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/safe-html.pipe.ts
+++ b/src/app/pipes/safe-html.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+@Pipe({
+  name: 'safeHtml'
+})
+export class SafeHtmlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value: any): SafeHtml {
+    return this.sanitizer.bypassSecurityTrustHtml(value);
+  }
+
+}

--- a/src/app/services/synthesis.service.spec.ts
+++ b/src/app/services/synthesis.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SynthesisService } from './synthesis.service';
+
+describe('SynthesisService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: SynthesisService = TestBed.get(SynthesisService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/synthesis.service.ts
+++ b/src/app/services/synthesis.service.ts
@@ -1,0 +1,145 @@
+import { Injectable } from '@angular/core';
+import { Story } from '../story';
+import { HttpClient } from '@angular/common/http';
+import config from '../../abairconfig.json';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SynthesisService {
+
+  constructor(private http: HttpClient) { }
+
+  baseUrl = config.baseurl;
+
+  /**
+   * Gets synthesis data for storyObject from
+   * the backend, which comes in the form of HTML data.
+   * Then parses that HTML data to populate Paragraph
+   * and Sentence objects.
+   * 
+   * @param storyObject - Story to be synthesised
+   * @returns - Paragraph and Sentence objects containing data for
+   * synthesis of input story.
+   */
+  async synthesiseStory(storyObject: Story): Promise<[Paragraph[], Sentence[]]> {
+    const synthesisResponse = await this.http.post(this.baseUrl + 'story/synthesiseObject/', {story: storyObject}).toPromise() as SynthesisResponse;
+    const sentences: Sentence[] = [];
+    const paragraphs: Paragraph[] = [];
+    synthesisResponse.html.forEach((sentenceHtmlArray, i) => {
+      let paragraphSentences: Sentence[] = [];
+      for (const sentenceHtml of sentenceHtmlArray) {
+        // sentenceSpan contains a span child for each word in the sentence
+        const sentenceSpan = this.textToElem(sentenceHtml) as HTMLSpanElement;
+        const sentence = new Sentence();
+        sentence.startTime = +sentenceSpan.children[0].getAttribute('data-begin');
+        const lastSentenceChild = sentenceSpan.children[sentenceSpan.childElementCount-1]
+        sentence.duration = (+lastSentenceChild.getAttribute('data-begin') + +lastSentenceChild.getAttribute('data-dur')) - sentence.startTime;
+        sentence.audio = new Audio(synthesisResponse.audio[i]);
+        sentence.spans = Array.from(sentenceSpan.children) as HTMLSpanElement[];
+        sentence.spans.forEach(span => span.classList.add('highlightable'));
+        sentences.push(sentence);
+        paragraphSentences.push(sentence);
+      }
+      const paragraph = new Paragraph();
+      paragraph.audio = new Audio(synthesisResponse.audio[i]);
+      paragraph.spans = paragraphSentences.reduce((acc, sentence) => acc.concat(sentence.spans), []);
+      paragraphs.push(paragraph);
+    });
+    return [paragraphs, sentences];
+  }
+
+  /**
+   * Converts a string of HTML code into a DOM Node object.
+   * 
+   * @param htmlString - String representation of a HTML object
+   * @returns - A DOM Node representing htmlString
+   */
+  textToElem(htmlString: string): Node {
+    var div = document.createElement('div');
+    div.innerHTML = htmlString.trim();
+    return div.firstChild; 
+  } 
+}
+
+/**
+ * Data structure to package / interact with synthesis data.
+ * Contains synthesis audio, and synthesised words in
+ * <span>s containing meta-data relevant to the synthesis
+ * of that word, such as start time and duration.
+ * 
+ * Also provides functions to play, pause, and highlight
+ * text in time with synthesis playback.
+ */
+export abstract class Section {
+
+  audio: HTMLAudioElement;
+  highlightTimeouts: NodeJS.Timer[] = [];
+  pauseTimeout: NodeJS.Timer;
+  spans: HTMLSpanElement[];
+  type: string;
+
+  play(startTime: number, duration: number) {
+    this.audio.currentTime = startTime;
+    this.audio.play();
+    this.pauseTimeout = setTimeout(() => {
+      this.stop();
+    }, duration * 1000);
+  }
+
+  stop() {
+    this.audio.pause();
+    this.audio.currentTime = 0;
+    clearTimeout(this.pauseTimeout);
+  }
+
+  highlight(startTime: number, duration: number) {
+    let previousSpan: HTMLSpanElement;
+    for (const s of this.spans) {
+      // Each span will be highlighted halfway through its playback.
+      // Each span is un-highlighted when the next span in the sequence
+      //  is highlighted.
+      this.highlightTimeouts.push(setTimeout(() => {
+        if (previousSpan) previousSpan.classList.add("noHighlight");
+        s.classList.add("highlight");
+        previousSpan = s;
+      }, ((+s.getAttribute("data-begin") * 1000)) + ((+s.getAttribute("data-dur") / 2) * 1000) - (startTime * 1000)));
+    }
+    this.highlightTimeouts.push(setTimeout(() => {
+      this.removeHighlight();
+    }, duration * 1000));
+  }
+
+  removeHighlight() {
+    for (const s of this.spans) {
+      s.classList.remove("highlight");
+      s.classList.remove("noHighlight");
+    }
+    this.highlightTimeouts.forEach(t => clearTimeout(t));
+  }
+}
+
+export class Paragraph extends Section {
+  play() {
+    super.play(0, this.audio.duration);
+  }
+  highlight() {
+    super.highlight(0, this.audio.duration);
+  }
+}
+
+export class Sentence extends Section {
+  startTime: number;
+  duration: number;
+  play() {
+    super.play(this.startTime, this.duration);
+  }
+  highlight() {
+    super.highlight(this.startTime, this.duration);
+  }
+}
+
+interface SynthesisResponse {
+  audio: string[];
+  html: Array<string[]>
+}

--- a/src/app/stop-sound.guard.ts
+++ b/src/app/stop-sound.guard.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, CanDeactivate } from '@angular/router';
 import { Observable } from 'rxjs';
 import { SynthesisComponent } from './student-components/synthesis/synthesis.component';
+import { SynthesisService } from './services/synthesis.service';
 
 @Injectable({
   providedIn: 'root'
@@ -13,9 +14,8 @@ export class StopSoundGuard implements CanDeactivate<SynthesisComponent> {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): Observable<boolean> | boolean {
-    if(synthesis.audioPlaying) {
-      synthesis.a.pause();
-      synthesis.audioPlaying = false;
+    for (const section of synthesis.chosenSections) {
+      section.stop();
     }
     return true;
   }

--- a/src/app/student-components/synthesis/synthesis.component.css
+++ b/src/app/student-components/synthesis/synthesis.component.css
@@ -288,11 +288,11 @@ Some pseudo-classes used to highlight text
 
 */
 
-.paragraphContainer ::ng-deep .spanText {
+.paragraphContainer ::ng-deep .highlightable {
     position: relative;
 }
 
-.paragraphContainer ::ng-deep .spanText::before {
+.paragraphContainer ::ng-deep .highlightable::before {
     content: '';
     height: 22px;
     width: 0%;
@@ -301,11 +301,11 @@ Some pseudo-classes used to highlight text
     transition: var(--trans);
 }
 
-.paragraphContainer ::ng-deep .spanTextHighlight::before {
+.paragraphContainer ::ng-deep .highlight::before {
     width: 100%;
 }
 
-.paragraphContainer ::ng-deep .spanTextNoHighlight::before {
+.paragraphContainer ::ng-deep .noHighlight::before {
     right: 0;
     width: 0%;
 }

--- a/src/app/student-components/synthesis/synthesis.component.html
+++ b/src/app/student-components/synthesis/synthesis.component.html
@@ -1,13 +1,14 @@
 <!-- Select the synthesis option for a story -->
 <img src="assets/img/book.png" class="bookImg">
 <div class="page">
+  <div class="paragraphContainer"></div>
   <div class="bookContainerSynth">
     <!-- back button to return to story -->
       <div class="bookHeader">
         <div (click)="goToDashboard()" class="myStoriesBtn"><i class="fa fa-chevron-left"></i> {{ts.l.story}}</div>
         <div></div>
       </div>
-      <div class="storyContainer" *ngIf="story">
+      <div class="storyContainer">
         <div class="storyHeader">
           {{ts.l.listen_and_correct}}
         </div>
@@ -21,38 +22,25 @@
               </div>
               <!-- When synthesis finished loading -->
               <div *ngIf="audioFinishedLoading">
-                <!-- loop through each paragraph of text -->
-                  <div *ngFor="let p of paragraphs" class="paragraphContainer">
-                    <!-- if paragraph option selected -->
-                    <span *ngIf="sectionSplit==='paragraph'">
-                      <span [innerHTML]="p.responseHtml" [attr.id]="'paragraph-' + p.index"></span>
-                      <button *ngIf="p.audioPlaying" (click)="stopAudio(p)" class="playAudioBtn"><i class="fas fa-pause"></i></button>
-                      <button *ngIf="!p.audioPlaying" (click)="playAudio(p)" class="playAudioBtn"><i class="fa fa-play"></i></button>
-                    </span>
-                    <!-- if sentence option selected -->
-                    <span *ngIf="sectionSplit==='sentence'">
-                      <!-- loop thorugh each sentence in the paragraph -->
-                      <div *ngFor="let s of p.sentences" class="sentenceContainer">
-                          <span [innerHTML]="s.responseHtml" [attr.id]="'sentence-' + s.index"></span>
-                          <button *ngIf="s.audioPlaying" (click)="stopAudio(s)" class="playAudioBtn"><i class="fas fa-pause"></i></button>
-                          <button *ngIf="!s.audioPlaying" (click)="playAudio(s)" class="playAudioBtn"><i class="fa fa-play"></i></button>
-                      </div>
-                    </span>
+                  <div *ngFor="let section of chosenSections" class="paragraphContainer">
+                    <span *ngFor="let span of section.spans" [innerHTML]="span.outerHTML | safeHtml"></span>
+                    <button *ngIf="!section.audio.paused" (click)="stopSection(section)" class="playAudioBtn"><i class="fas fa-pause"></i></button>
+                    <button *ngIf="section.audio.paused" (click)="playSection(section)" class="playAudioBtn"><i class="fa fa-play"></i></button>
                   </div>
               </div>
             </div>
             <!-- Choose paragraph or Sentence buttons -->
             <div class="footer">
-              <div class="btnContainer">
+              <div class="btnContainer" *ngIf="audioFinishedLoading">
                 <div class="footerText">
                   {{ts.l.listen_by}}
                 </div>
-                <div *ngIf="sectionSplit==='paragraph'">
+                <div *ngIf="isParagraphMode()">
                   <button class="changeSplitBtn selectedBtn">{{ts.l.paragraph}}</button>
-                  <button class="changeSplitBtn" (click)="sentenceMode()">{{ts.l.sentence}}</button>
+                  <button class="changeSplitBtn" (click)="changeSections(sentences)">{{ts.l.sentence}}</button>
                 </div>
-                <div *ngIf="sectionSplit==='sentence'">
-                  <button class="changeSplitBtn" (click)="paragraphMode()">{{ts.l.paragraph}}</button>
+                <div *ngIf="isSentenceMode()">
+                  <button class="changeSplitBtn" (click)="changeSections(paragraphs)">{{ts.l.paragraph}}</button>
                   <button class="changeSplitBtn selectedBtn">{{ts.l.sentence}}</button>
                 </div>
               </div>

--- a/src/app/student-components/synthesis/synthesis.component.ts
+++ b/src/app/student-components/synthesis/synthesis.component.ts
@@ -56,7 +56,6 @@ export class SynthesisComponent implements OnInit {
   }
 
   playSection(section) {
-    console.log('PLAY SECTION:', section.audio)
     section.play();
     section.highlight();
   }

--- a/src/app/student-components/synthesis/synthesis.component.ts
+++ b/src/app/student-components/synthesis/synthesis.component.ts
@@ -6,6 +6,8 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { EventType } from '../../event';
 import { EngagementService } from '../../engagement.service';
 import { TranslationService } from '../../translation.service';
+import { SynthesisService, Paragraph, Sentence, Section } from '../../services/synthesis.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-synthesis',
@@ -16,339 +18,54 @@ export class SynthesisComponent implements OnInit {
 
   constructor(private storyService: StoryService, private route: ActivatedRoute,
               private router: Router, private sanitizer: DomSanitizer,
-              private engagement: EngagementService, public ts : TranslationService) { }
-
-  story: Story;
+              private engagement: EngagementService, public ts : TranslationService,
+              private synthesis: SynthesisService) { }
+ 
+  storyId: string;
   paragraphs: Paragraph[] = [];
   sentences: Sentence[] = [];
+  chosenSections: Section[];
   audioFinishedLoading: boolean = false;
-  a;
-  audioPlaying: boolean = false;
-  sectionSplit : string = "paragraph";
-  audioTimeouts = [];
 
-/*
-* Get paragaph and sentence data from the synthesiser 
-*/
   ngOnInit() {
-    this.getStory().then((s) => {
-      this.storyService.synthesise(this.story._id).subscribe((res) => {
-        console.log('res:', res);
-        // loop through the html of the synthesis response and create sentences/paragraph instances
-        for(let p of res.html) {
-          let paragraphStr: string = "";
-          let paragraphObject = new Paragraph();
-          for(let sentenceStr of p) {
-            paragraphStr += sentenceStr;
-            let sentence = new Sentence();
-            sentence.responseHtml = this.sanitizer.bypassSecurityTrustHtml(sentenceStr);
-            sentence.audioPlaying = false;
-            sentence.paragraph = paragraphObject;
-            paragraphObject.sentences.push(sentence);
-            this.sentences.push(sentence);
-          }
-          paragraphObject.responseHtml = this.sanitizer.bypassSecurityTrustHtml(paragraphStr);
-          paragraphObject.audioPlaying = false;
-          this.paragraphs.push(paragraphObject);
-        }
-        let j = 0;
-        // loop through the audio of the synthesis response and add to sentence/paragraph instances
-        for(let i in res.audio) {
-          this.paragraphs[i].audioUrl = res.audio[i];
-          this.paragraphs[i].index = i;
-          for(let s of this.paragraphs[i].sentences) {
-            s.index = j;
-            ++j;
-          }
-        }
-        this.engagement.addEventForLoggedInUser(EventType["SYNTHESISE-STORY"], this.story);
+    this.storyId = this.route.snapshot.paramMap.get('id');
+    this.storyService.getStory(this.storyId).subscribe((story) => {
+      this.synthesis.synthesiseStory(story).then(([paragraphs, sentences]) => {
+        this.paragraphs = paragraphs;
+        this.sentences = sentences;
+        this.chosenSections = this.paragraphs;
         this.audioFinishedLoading = true;
-        this.paragraphMode();
       });
     });
   }
 
-/*
-* Set the html format for paragraph mode
-*/
-  paragraphMode() {
-    this.sectionSplit = "paragraph";
-    this.pauseAllAudio();
-    setTimeout(() => {
-      this.paragraphs.forEach(p => {
-        console.log(p.index);
-        let pElem = document.getElementById("paragraph-" + p.index);
-        if(pElem) {
-          let spans = pElem.querySelectorAll('span');
-          spans.forEach(span => {
-            if(span.className != "sentence_normal") {
-              span.addEventListener('click', this.playWord.bind(this));
-              span.setAttribute("audio-url", p.audioUrl);
-              span.classList.add("wordBtn");
-            }
-          })
-        }
-      });
-    }, 1000);
+  //--- UI Manipulation ---//
+
+  isSentenceMode() {
+    return this.chosenSections[0] instanceof Sentence;
   }
 
-/*
-* Set the html for sentence mode
-*/
-  sentenceMode() {
-    this.sectionSplit = "sentence";
-    this.pauseAllAudio();
-    setTimeout(() => {
-      this.sentences.forEach(s => {
-        let sElem = document.getElementById("sentence-" + s.index);
-        if(sElem) {
-          let spans = sElem.children[0].querySelectorAll('span');
-          spans.forEach(span => {
-            if(span.className != "sentence_normal") {
-              span.addEventListener('click', this.playWord.bind(this));
-              span.setAttribute("audio-url", s.paragraph.audioUrl);
-              span.classList.add("wordBtn");
-            }
-          })
-        }
-      });
-    }, 1000);
+  isParagraphMode() {
+    return this.chosenSections[0] instanceof Paragraph;
   }
 
-/*
-* Play the audio of a word when it is clicked 
-* Method bound to event target in sentence/paragraphMode functions
-*/
-  playWord(event) {
-    let span = event.target;
-    this.pauseAllAudio();
-    this.a = new Audio(span.getAttribute("audio-url"));
-    let time = span.getAttribute("data-begin");
-    console.log(time, time-0.1);
-    let duration = span.getAttribute("data-dur");
-    this.a.currentTime = time;
-    this.a.play();
-    span.style.background = "#0088ff6b";
-    let t = setTimeout(() => {
-      this.a.pause();
-      span.classList.remove("staticHighlight");
-      span.style.background = "#00000000";
-    }, duration * 1500);
-    this.audioTimeouts.push(t);
+  changeSections(sections) {
+    this.chosenSections = sections;
+    const allSections = this.paragraphs.concat(this.sentences);
+    allSections.forEach(section => this.stopSection(section));
   }
 
-/*
-* Get story using story service
-*/
-  getStory() {
-    return new Promise((resolve, reject) => {
-        this.getParamsFromUrl().then((params) => {
-        this.storyService.getStory(params['id'].toString()).subscribe((res : Story) => {
-          this.story = res;
-          resolve(res);
-        });
-      });
-    });
-  }
-  
-/*
-* Get story id from url parameters (function called in getStory())
-*/
-  getParamsFromUrl() {
-    return new Promise((resolve, reject) => {
-      this.route.params.subscribe(
-        params => {
-          console.log(params);
-          resolve(params);
-      });
-    });
+  playSection(section) {
+    section.play();
+    section.highlight();
   }
 
-/*
-* Set audioPlaying to false for all sentences/paragraphs
-*/
-  pauseAllAudio() {
-    if(this.a) {
-      this.a.pause();
-      this.audioPlaying = false;
-      this.paragraphs.forEach((para) => {
-        if(this.sectionSplit === "paragraph") {
-          para.audioPlaying = false;
-          Highlighter.stopHighlighting(para);
-        } else if(this.sectionSplit === "sentence")  {
-          para.sentences.forEach(sentence => {
-            sentence.audioPlaying = false;
-            Highlighter.stopHighlighting(sentence);
-          });
-          this.audioTimeouts.forEach(t => {
-            clearTimeout(t);
-          })
-        }
-      })
-    }
-  }
-
-/*
-* Play audio for each paragraph/sentence using the audio url and start highlighting
-*/
-  playAudio(section) {
-    this.pauseAllAudio();
-    console.log(section.type);
-    if(section.type === "Paragraph") {
-      this.a = new Audio(section.audioUrl);
-      this.a.play();
-      this.audioPlaying = true;
-      Highlighter.startHighlighting(section);
-    } else if(section.type === "Sentence") {
-      let sentenceElement = document.getElementById('sentence-' + section.index);
-      // calculate sentence start time
-      if(!section.startTime) {
-        section.startTime = sentenceElement.children[0].children[0].getAttribute("data-begin");
-      }
-      // calculate sentence duration
-      if(!section.duration) {
-        section.duration = +sentenceElement.children[0].children[sentenceElement.children[0].childElementCount-1].getAttribute("data-begin")
-        + +sentenceElement.children[0].children[sentenceElement.children[0].childElementCount-1].getAttribute("data-dur")
-        - section.startTime;
-      }
-      // set the audio player to start at the sentence start time
-      this.a = new Audio(section.paragraph.audioUrl);
-      this.a.currentTime = section.startTime;
-      this.a.play();
-      this.audioPlaying = true;
-      Highlighter.startHighlighting(section);Highlighter.startHighlighting(section);
-      let t = setTimeout(()=> {
-        this.a.pause();
-        this.audioPlaying = false;
-      }, section.duration * 1000);
-      this.audioTimeouts.push(t);
-    }
-    
-  }
-
-/*
-* Pause the audio player and stop highlighting
-*/
-  stopAudio(section) {
-    this.a.pause();
-    this.audioPlaying = false;
-    Highlighter.stopHighlighting(section);
+  stopSection(section) {
+    section.stop();
+    section.removeHighlight();
   }
 
   goToDashboard() {
-    this.router.navigateByUrl('/dashboard/' + this.story.id);
+    this.router.navigateByUrl('/dashboard/' + this.storyId);
   }
-
-}
-
-/***************************** ASSOCIATED CLASSES *****************************/
-
-class Paragraph {
-    index: string;
-    audioUrl: string;
-    responseHtml: SafeHtml;
-    audioPlaying: boolean;
-    highlightTimeouts = [];
-    sentences : Sentence[] = [];
-    type: string = "Paragraph";
-}
-
-class Sentence {
-  index : string = "0";
-  responseHtml : SafeHtml;
-  audioPlaying : boolean;
-  highlightTimeouts = [];
-  startTime : number;
-  duration : number;
-  paragraph : Paragraph;
-  type: string = "Sentence";
-}
-
-class Highlighter {
-
-  static startHighlighting(section) {
-    section.audioPlaying = true;
-
-    let isParagraph = section.type === "Paragraph";
-    let isSentence = section.type === "Sentence";
-
-    // select all the span elements associated with each paragraph / sentence
-    let spans, delay = 0;
-    if(isParagraph) {
-      let sectionElement = document.getElementById('paragraph-' + section.index);
-      spans = sectionElement.querySelectorAll('span');
-    } else if(isSentence) {
-      let sectionElement = document.getElementById('sentence-' + section.index);
-      spans = sectionElement.children[0].querySelectorAll('span');
-      delay = section.startTime * 1000;
-    }
-    
-    let previousSpan: HTMLSpanElement;
-
-    spans.forEach((s) => {
-      if(s.className != 'sentence_normal') {
-        s.classList.add("spanText");
-      }
-    });
-
-    // set and reset the css classes for each highlighted item
-    spans.forEach((s, i) => {
-      if(s.className != 'sentence_normal') {
-        let t = setTimeout(() => {
-          if(i === spans.length-1) {
-            setTimeout(() => {
-              s.classList.add("spanTextNoHighlight");
-              s.classList.remove("spanTextHighlight");
-              this.resetHighlight(section);
-            }, (+s.getAttribute("data-dur")) * 1000);
-          }
-          if(previousSpan) {
-            previousSpan.classList.add("spanTextNoHighlight");
-          }
-          s.classList.add("spanTextHighlight");
-          s.style.setProperty('--trans', "width " + (+s.getAttribute("data-dur") / 2 ).toString() + "s  ease-in-out");
-          previousSpan = s;
-        }, ((+s.getAttribute("data-begin") * 1000)) + ((+s.getAttribute("data-dur") / 2) * 1000) - delay);
-        section.highlightTimeouts.push(t);
-      }
-    }); 
-    
-  }
-
-  static stopHighlighting(section) {
-    section.highlightTimeouts.forEach((t) => {
-      clearTimeout(t);
-    });
-    this.resetHighlight(section);
-  }
-
-  static resetHighlight(section) {
-    section.audioPlaying = false;
-
-    let isParagraph = section.type === "Paragraph";
-    let isSentence = section.type === "Sentence";
-
-    let spans;
-    if(isParagraph) {
-      let sectionElement = document.getElementById('paragraph-' + section.index);
-      if(sectionElement) {
-        spans = sectionElement.querySelectorAll('span');
-      }
-    } else if(isSentence) {
-      let sectionElement = document.getElementById('sentence-' + section.index);
-      if(sectionElement) {
-        spans = sectionElement.children[0].querySelectorAll('span');
-      }
-    }
-
-    if(spans) {
-      spans.forEach((s) => {
-        s.classList.remove("spanText");
-        s.classList.remove("spanTextHighlight");
-        s.classList.remove("spanTextNoHighlight");
-      });
-    }
-    
-  }
-
 }

--- a/src/app/student-components/synthesis/synthesis.component.ts
+++ b/src/app/student-components/synthesis/synthesis.component.ts
@@ -56,6 +56,7 @@ export class SynthesisComponent implements OnInit {
   }
 
   playSection(section) {
+    console.log('PLAY SECTION:', section.audio)
     section.play();
     section.highlight();
   }

--- a/src/app/student-components/synthesis/synthesis.component.ts
+++ b/src/app/student-components/synthesis/synthesis.component.ts
@@ -55,7 +55,7 @@ export class SynthesisComponent implements OnInit {
     allSections.forEach(section => this.stopSection(section));
   }
 
-  playSection(section) {
+  playSection(section: Section) {
     section.play();
     section.highlight();
   }


### PR DESCRIPTION
**Summary**
* Refactored code for the synthesis page.
* This involved moving the data processing from the synthesis.component to a synthesis.service file (in general I think we should start putting any code that is used in multiple components / does anything that isn't directly related to UI in services).
* Introduced some new data structures to handle interacting with syntheses (see `Section`, `Paragraph`, `Sentence`).
* Storing synthesis word spans as `HTMLSpanElements` made playback control and the word highlighting feature _much_ easier, as it means we no longer have to use queryselectors to find any `<span>` we want to work with in .ts files.
* Some description of the service is given in [this doc](https://docs.google.com/document/d/1VRibA5JAHAE75FsLJBa4yqp5rmwIEzi3Pi4SQTyPFKk/edit?usp=sharing).
* Also, I noticed that the timing meta-data we use for playing individual words' syntheses was slightly off, so I just removed that code for now (only a couple of lines -- easy to add back if needs be). It would probably sound much better if we synthesised each word individually, although this may be very inefficient?

**To do**
* In another PR I'll update the recording components to use this synthesis service.