### PR TITLE
Small dashboard CSS changes

### DIFF
--- a/ngapp/src/app/student-components/dashboard/dashboard.component.html
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.html
@@ -103,7 +103,7 @@
       <!-- display story before grammar checked (i.e. writing mode)-->
       <div class="textFieldContainer"  *ngIf="!feedbackVisible && !grammarChecked && !grammarLoading && !dictionaryVisible">
         <textarea mwlTextInputElement class="textField" [(ngModel)]="story.text" (input)="storyEdited()" spellcheck="false"></textarea>
-<div style="display: flex; align-items: center; justify-content: center; padding-bottom: 6px">
+<div style="display: flex; align-items: center; padding-bottom: 6px; padding-left: 8px;">
   <span> {{ts.l.word_count}}: {{wordCount}} </span>
 </div>
       </div>

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.ts
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.ts
@@ -46,7 +46,7 @@ export class DashboardComponent implements OnInit {
   classroomId: string;
   selectTeanglann: boolean = true;
   selectExternalLinks: boolean = false;
-  showOptions: boolean = false;
+  showOptions: boolean = true;
   dontToggle: boolean = false;
   words: string[] = [];
   wordCount: number = 0;


### PR DESCRIPTION
* Made two small changes to dashboard UI:
    * Options toggled _on_ by default, I think this is more user-friendly.
    * Word-count floated left, this seems neater to me than centered.
* What are your thoughts on this? Improvement / disimprovement?

Here's how it looks:
<img width="1267" alt="Screenshot 2021-06-26 at 16 38 47" src="https://user-images.githubusercontent.com/34962541/123518423-c946c500-d69d-11eb-8b35-5fc6084da4fc.png">
