### PR TITLE
Filter student stories by date in classroom view

### DIFF
--- a/api/routes/story.route.js
+++ b/api/routes/story.route.js
@@ -67,6 +67,20 @@ storyRoutes.route('/:author').get(function (req, res) {
   });
 });
 
+// Get stories by a given author after a certain date from DB
+storyRoutes.route('/getStoriesForClassroom/:author/:date').get(function (req, res) {
+  Story.find({"author": req.params.author, date: {$gte: req.params.date}}, function (err, stories) {
+    if(err) {
+      console.log(err);
+      res.json(err)
+    } else {
+      console.log("function read");
+      console.log("stories: ", stories);
+      res.json(stories);
+    }
+  });
+});
+
 // Get story with a given ID from DB
 storyRoutes.route('/viewStory/:id').get(function(req, res) {
   Story.find({_id:req.params.id}, (err, story) => {

--- a/api/routes/story.route.js
+++ b/api/routes/story.route.js
@@ -74,8 +74,6 @@ storyRoutes.route('/getStoriesForClassroom/:author/:date').get(function (req, re
       console.log(err);
       res.json(err)
     } else {
-      console.log("function read");
-      console.log("stories: ", stories);
       res.json(stories);
     }
   });

--- a/api/test/server.js
+++ b/api/test/server.js
@@ -8,6 +8,63 @@ var request = require("request");
 
 describe("API Server", () => {
   describe("Story Routes", () => {
+    describe("/story/getStoriesForClassroom/:author/:date", () => {
+
+      let url = `http://localhost:4000/story/getStoriesForClassroom/notAnAuthor/notADate`;
+      it('should respond with statusCode 400 since notADate cannot be cast to a date. url: ' + url, function(done){
+        request({
+          headers: {
+            'Content-Type': 'application/json' 
+          },
+          uri: url
+        }, function(error, response, body) {
+          console.dir(response.statusCode);
+          console.dir(body);
+          expect(response.statusCode).to.equal(400);
+          done();
+        });
+      });
+
+      // db.story.find({
+      //  author: "neimhin",
+      //  date: {$gte: ISODate("2020-07-11T21:00:00.139Z")}})
+      // // gives 8 documents
+      url = `http://localhost:4000/story/getStoriesForClassroom/neimhin/${encodeURIComponent('2020-07-11T21:00:00.139Z')}`;
+      it('should respond with at least one story by neimhin ' +
+        'url: ' + url, function(done) {
+        request({
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          uri: url,
+        }, function(error, response, body) {
+          console.dir(response.statusCode);
+          console.dir(body);
+          expect(response.statusCode).to.equal(200);
+          expect(JSON.parse(body).length).to.be.greaterThan(1);
+          done();
+        });
+      });
+ 
+      url = `http://localhost:4000/story/getStoriesForClassroom/notAnAuthor/${new Date()}`;
+      it(
+          'should respond with an empty list ' +
+          'since there have been no stories created after right now. ' +
+          'url: ' + url,
+          function(done) {
+            request({
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              uri: url,
+            }, function(error, response, body) {
+              // expect body to be the string '[]'
+              expect(body.match(/[]/));
+              done();
+            });
+          });
+    });
+
     describe("/story/getStoryById/:id", () => {
       let url123 = `http://localhost:4000/story/getStoryById/123`;
       it("should search the database for a story with id 123", function(done){
@@ -17,8 +74,6 @@ describe("API Server", () => {
           },
           uri: url123
         }, function(error, response, body) {
-          console.log(response.statusCode);
-          console.log(body);
           expect(response.statusCode).to.equal(404);
           done();
         });
@@ -34,8 +89,6 @@ describe("API Server", () => {
               },
               uri: url2
             }, function(error, response, body) {
-              console.log(response.statusCode);
-              console.log(body);
               expect(response.statusCode).to.equal(200);
               done();
             }

--- a/ngapp/src/app/story.service.ts
+++ b/ngapp/src/app/story.service.ts
@@ -61,6 +61,10 @@ export class StoryService {
     const author = userDetails.username;
     return this.http.get(this.baseUrl+author);
   }
+  
+  getStoriesForClassroom(author: string, date): Observable<any> {
+    return this.http.get(this.baseUrl + "getStoriesForClassroom/" + author + "/" + date);
+  }
 
   updateStory(data, id) : Observable<any> {
     return this.http.post(this.baseUrl + 'update/' +id, data);

--- a/ngapp/src/app/teacher-components/teacher-classroom/teacher-classroom.component.ts
+++ b/ngapp/src/app/teacher-components/teacher-classroom/teacher-classroom.component.ts
@@ -88,10 +88,18 @@ export class TeacherClassroomComponent implements OnInit {
         //this.students.sort((a, b) => (a.username < b.username) ? -1 : 1);
         this.students.sort((a, b) => a.username.toLowerCase().localeCompare(b.username.toLowerCase()));
         this.studentIds.push(res._id);
-        this.storyService.getStoriesFor(res.username).subscribe( (stories) => {
-          let count = Object.keys(stories).length;
-          this.numOfStories.set(res.username, count);
-        })
+        if(this.classroom.date) {
+          this.storyService.getStoriesForClassroom(res.username, this.classroom.date).subscribe( (stories) => {
+            let count = Object.keys(stories).length;
+            this.numOfStories.set(res.username, count);
+          });
+        }
+        else {
+          this.storyService.getStoriesFor(res.username).subscribe( (stories) => {
+            let count = Object.keys(stories).length;
+            this.numOfStories.set(res.username, count);
+          });
+        }
       });
     }
   }

--- a/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.css
+++ b/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.css
@@ -188,3 +188,19 @@
     color:#ff9100;
     transition: color, 0.5s;
 }
+
+.lastUpdated {
+  display: flex;
+  flex-direction: row;
+}
+
+.sortIcon {
+  padding-left:10px;
+  padding-top: 5px;
+}
+
+.sortIcon:hover {
+  cursor: pointer;
+  color:#ff9100;
+  transition: color, 0.5s;
+}

--- a/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.html
+++ b/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.html
@@ -16,7 +16,11 @@
         </div>
         <div class="classroomKey">
           <div class="title">{{ts.l.title}}</div>
-          <div> {{ts.l.last_updated}} </div> <div> </div>
+          <div class="lastUpdated"> 
+            <div> {{ts.l.last_updated}} </div>
+            <i *ngIf="dateDescending" class="fas fa-angle-down sortIcon" (click)="sortStories()"></i> 
+            <i *ngIf="!dateDescending" class="fas fa-angle-up sortIcon" (click)="sortStories()"></i> 
+          </div><div> </div>
         </div>
         <!-- list of stories -->
         <div class="classBody" *ngIf="!viewNoFeedback">

--- a/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.ts
+++ b/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.ts
@@ -26,6 +26,7 @@ export class TeacherStudentComponent implements OnInit {
     storiesWithoutFeedback: Story[] = [];
     userId: string;
     classroomId: string;
+    classroomDate;
     viewNoFeedback: boolean = false;
 
     baseUrl: string = config.baseurl;
@@ -45,12 +46,7 @@ export class TeacherStudentComponent implements OnInit {
           this.userId = params['id'].toString();
           this.student = res;
           this.setClassroomId();
-          this.storyService
-            .getStoriesFor(this.student.username)
-            .subscribe(
-              (data: Story[]) => {
-            this.stories = data, this.filterFeedback(data);
-          });
+          
         });
       });
     }
@@ -63,9 +59,19 @@ export class TeacherStudentComponent implements OnInit {
       }
     }
     
-    setClassroomId() {
+    setClassroomId(){
       this.classroomService.getClassroomOfStudent(this.userId).subscribe((res) => {
         this.classroomId = res._id;
+        if(res.date) {
+          this.storyService.getStoriesForClassroom(this.student.username, res.date).subscribe((data: Story[]) => {
+            this.stories = data, this.filterFeedback(data);
+          });
+        }
+        else {
+          this.storyService.getStoriesFor(this.student.username).subscribe((data: Story[]) => {
+            this.stories = data, this.filterFeedback(data);
+          });
+        }
       });
     }
   

--- a/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.ts
+++ b/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.ts
@@ -27,6 +27,7 @@ export class TeacherStudentComponent implements OnInit {
     userId: string;
     classroomId: string;
     viewNoFeedback: boolean = false;
+    dateDescending: boolean = false;
 
     baseUrl: string = config.baseurl;
   
@@ -81,6 +82,26 @@ export class TeacherStudentComponent implements OnInit {
             resolve(params);
         });
       });
+    }
+    
+    sortStories() {
+      this.dateDescending = !this.dateDescending;
+      if(this.viewNoFeedback){
+        if(this.dateDescending) {
+          this.storiesWithoutFeedback.sort((a, b) => (a.date > b.date) ? -1 : 1);
+        }
+        else {
+          this.storiesWithoutFeedback.sort((a, b) => (a.date > b.date) ? 1 : -1);
+        }
+      }
+      else {
+        if(this.dateDescending) {
+          this.stories.sort((a, b) => (a.date > b.date) ? -1 : 1);
+        }
+        else {
+          this.stories.sort((a, b) => (a.date > b.date) ? 1 : -1);
+        }  
+      }
     }
   
     goToStory(storyId) {

--- a/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.ts
+++ b/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.ts
@@ -26,7 +26,6 @@ export class TeacherStudentComponent implements OnInit {
     storiesWithoutFeedback: Story[] = [];
     userId: string;
     classroomId: string;
-    classroomDate;
     viewNoFeedback: boolean = false;
 
     baseUrl: string = config.baseurl;


### PR DESCRIPTION
Teachers can only view student stories that were created since the classroom creation date.

- Example:
  - Max has 6 stories total created between April - July.
  - After joining a classroom that was created in July, teacher can only see those stories created since then (3 stories)
<img width="1649" alt="Captura de Pantalla 2021-07-09 a la(s) 17 08 06" src="https://user-images.githubusercontent.com/13711456/125099380-3ca5f900-e0d8-11eb-9eee-9d969ff76a31.png">

<img width="1662" alt="Captura de Pantalla 2021-07-09 a la(s) 17 06 52" src="https://user-images.githubusercontent.com/13711456/125099206-108a7800-e0d8-11eb-99ff-89cb03b23533.png">


- Note
  - Classroom date attributes were only added in April, so any classrooms created before then will not be able to filter stories
  - In this situation classrooms will be able to see all the student's stories regardless of when they jointed the class

- Code change
  - Added an endpoint to find stories given an author and a date in the story route
  - ```teacher-student``` component and ```teacher-classroom``` component use this endpoint in the same way:
    - if a classroom date exists, call the new endpoint
    - if the date does not exist, call the old endpoint (get stories just by author)
  - Not the most elegant code, it could probably be cleaned up a bit   

