### PR TITLE
faster word count using only split()

### DIFF
--- a/ngapp/src/app/student-components/dashboard/dashboard.component.html
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.html
@@ -105,7 +105,7 @@
       <div class="textFieldContainer"  *ngIf="!feedbackVisible && !grammarChecked && !grammarLoading && !dictionaryVisible">
         <!--<textarea mwlTextInputElement class="textField" [(ngModel)]="story.text" (input)="storyEdited()" spellcheck="false"></textarea>-->
         
-        <quill-editor [modules]="quillToolbar" placeholder="" [preserveWhitespace]="true" [(ngModel)]="story.htmlText" (onContentChanged)="storyEdited($event.text); getWordCount($event.text)"></quill-editor>
+        <quill-editor [modules]="quillToolbar" placeholder="" [preserveWhitespace]="true" [(ngModel)]="story.htmlText" (onContentChanged)="storyEdited($event.text); updateWordCount($event.text)"></quill-editor>
          
       </div>
 
@@ -161,7 +161,7 @@
         <div class="feedbackHeader"><div>{{ts.l.feedback}}</div> <div class="closeFeedbackBtn" (click)="closeFeedback()"><i class="fa fa-times"></i></div></div>
         <textarea class="textField feedbackTextarea" placeholder="{{ts.l.no_feedback_provided}}" readonly value="{{story?.feedback.text}}"></textarea>
         <!--<textarea class="textField feedbackVisibleTextfield" value="{{story?.text}}" [(ngModel)]="story.text" (input)="storyEdited()"></textarea>-->
-        <quill-editor [modules]="quillToolbar" placeholder="" [preserveWhitespace]="true" [(ngModel)]="story.htmlText" (onContentChanged)="storyEdited($event.text); getWordCount($event.text)"></quill-editor>
+        <quill-editor [modules]="quillToolbar" placeholder="" [preserveWhitespace]="true" [(ngModel)]="story.htmlText" (onContentChanged)="storyEdited($event.text); updateWordCount($event.text)"></quill-editor>
         
       </div>
       <!-- display story with feedback including audio feedback -->
@@ -171,7 +171,7 @@
         <audio *ngIf="audioSource" [src]="audioSource" id="audio" controls #audioTag class="audioPlayer"></audio>
         <!--<textarea class="textField feedbackVisibleTextfieldAudio" value="{{story?.text}}" [(ngModel)]="story.text" (input)="storyEdited()"></textarea>-->
         
-        <quill-editor [modules]="quillToolbar" placeholder="" [preserveWhitespace]="true" [(ngModel)]="story.htmlText" (onContentChanged)="storyEdited($event.text); getWordCount($event.text)"></quill-editor>
+        <quill-editor [modules]="quillToolbar" placeholder="" [preserveWhitespace]="true" [(ngModel)]="story.htmlText" (onContentChanged)="storyEdited($event.text); updateWordCount($event.text)"></quill-editor>
         
       </div>
 
@@ -179,7 +179,7 @@
       <div class="dictionaryModeContainer" *ngIf="dictionaryVisible && !feedbackVisible && !grammarChecked && !grammarLoading">
         <!--<textarea class="textField dictionaryVisibleTextField" value="{{story?.text}}" [(ngModel)]="story.text" (input)="storyEdited()"></textarea>-->
         
-        <quill-editor class="quill-editor-dict" [modules]="quillToolbar" placeholder="" [preserveWhitespace]="true" [(ngModel)]="story.htmlText" (onContentChanged)="storyEdited($event.text); getWordCount($event.text)"></quill-editor>
+        <quill-editor class="quill-editor-dict" [modules]="quillToolbar" placeholder="" [preserveWhitespace]="true" [(ngModel)]="story.htmlText" (onContentChanged)="storyEdited($event.text); updateWordCount($event.text)"></quill-editor>
         
         <div class="dictionaryContainer">
           <div class="dictionaryHeader"><div>{{ts.l.dictionary}}</div> <div class="closeDictionaryBtn" (click)="dictionaryVisible = false;"><i class="fa fa-times"></i></div></div>

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.ts
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.ts
@@ -112,7 +112,7 @@ export class DashboardComponent implements OnInit {
         for(let story of this.stories) {
           if(story._id === this.id) {
             this.story = story;
-            this.getWordCount(this.story.text);
+            this.updateWordCount(this.story.text);
             if(this.story.htmlText == null) {
               this.story.htmlText = this.story.text;
             }
@@ -220,17 +220,13 @@ export class DashboardComponent implements OnInit {
   }
   
 // Get word count of story text
-  getWordCount(text) {
-    let str = text.replace(/[\t\n\r\.\?\!]/gm, " ").split(" ");
-    this.words = [];
-    str.map((s) => {
-      let trimStr = s.trim();
-      if (trimStr.length > 0) {
-        this.words.push(trimStr);
-      }
-      
-    });
-    this.wordCount = this.words.length;
+  updateWordCount(text) {
+    const regex = /[^a-z0-9]+/i;
+    /* OTHER OPTIONS
+    const regex = /[\s]+/
+    const regex = /[\s\.\!\?]/
+    */
+    this.wordCount = this.story.text.split(regex).length;
   }
 
 // set feedback window to false 

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.ts
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.ts
@@ -219,14 +219,15 @@ export class DashboardComponent implements OnInit {
     
   }
   
-// Get word count of story text
+  // Get word count of story text
   updateWordCount(text) {
-    const regex = /[^a-z0-9]+/i;
+    // don't use . as word boundary
+    const regex = /[^a-z0-9\.]+/i;
     /* OTHER OPTIONS
     const regex = /[\s]+/
     const regex = /[\s\.\!\?]/
     */
-    this.wordCount = this.story.text.split(regex).length;
+    this.wordCount = this.story.text.slice(1).split(regex).length - 1;
   }
 
 // set feedback window to false 


### PR DESCRIPTION
THIS IS NOT WORKING ATM

Seems to me the word count function was making some redundant passes over the text.

With the method suggested here I believe we're making only one pass over the text to get the word count.

### bug:
I'm trying to figure out why when the editor is empty it splits an empty string into ["",""].