### PR TITLE
gramadoirDirectObservable function with map to QuillHighlightTag

### DIFF
--- a/ngapp/src/app/grammar.service.ts
+++ b/ngapp/src/app/grammar.service.ts
@@ -1,28 +1,50 @@
-import { Injectable } from '@angular/core';
+import {
+  Injectable,
+} from '@angular/core';
+import {
+  HttpClient,
+} from '@angular/common/http';
 import { Observable, Observer ,  of } from 'rxjs';
 import { StoryService } from './story.service';
 import { HighlightTag } from 'angular-text-input-highlight';
 import { catchError, skip } from 'rxjs/operators';
 import { Story } from './story';
 
+export type GramadoirTag = {
+  fromy: string;
+  fromx: number;
+  toy: string;
+  tox: number;
+  ruleId: string;
+  msg: string;
+  contex: string;
+  contextoffset: string;
+  errortext: string;
+  errorlength: string;
+};
+
 @Injectable({
   providedIn: 'root'
 })
 export class GrammarService {
-  
+  gramadoirUrl = 'https://www.abair.ie/cgi-bin/api-gramadoir-1.0.pl';
+
   broad = ['a', 'o', 'u', 'á', 'ó', 'ú', 'A', 'O', 'U', 'Á', 'Ó', 'Ú'];
   slender = ['e', 'i', 'é', 'í', 'E', 'I', 'É', 'Í'];
   consonants = ['b', 'c', 'd', 'f', 'g', 'h', 'l', 'm', 'n', 'p', 'r', 's', 't', 'v', 'z', 'B', 'C', 'D', 'F', 'G', 'H', 'L', 'M', 'N', 'P', 'R', 'S', 'T', 'V', 'Z'];
   ignore = ['aniar', 'aníos', 'aréir', 'arís', 'aríst', 'anseo', 'ansin', 'ansiúd', 'cén', 'den', 'faoina', 'ina', 'inar', 'insa', 'lena', 'lenar'];
 
-  constructor(private storyService: StoryService, ) { }
+  constructor(
+    private storyService: StoryService,
+    private http: HttpClient,
+  ) { }
 
-/*
-* Set grammar and vowel tags of TagSet object 
-*/
-  checkGrammar(id: string) : Observable<any> {
+  /*
+  * Set grammar and vowel tags of TagSet object
+  */
+  checkGrammar(id: string): Observable<any> {
     return Observable.create((observer: Observer<any>) => {
-      let tagSets : TagSet = new TagSet;
+      let tagSets: TagSet = new TagSet;
       // get a story object given an id
       this.storyService.getStory(id).subscribe((story: Story) => {
         // get grammar tags for the story object
@@ -52,9 +74,45 @@ export class GrammarService {
     });
   }
 
-/*
-* Get grammar tag data from an gramadoir
-*/
+
+  gramadoirXWwwFormUrlencodedRequestData(input: string, language: 'en' | 'ga') {
+    return `teacs=${encodeURIComponent(input)}&teanga=${language}`;
+  }
+
+  async gramadoirDirect(text: string, language: 'en' | 'ga', signal: AbortSignal): Promise<GramadoirTag[]> {
+    const res = await fetch(this.gramadoirUrl, {
+         headers: {
+           'Content-Type': 'application/x-www-form-urlencoded',
+         },
+         method: 'POST',
+         signal,
+         body: this.gramadoirXWwwFormUrlencodedRequestData(text.replace(/\n/g, ' '), language)
+       });
+
+    if (res.ok) {
+      return res.json();
+    }
+
+    throw new Error(res.statusText);
+  }
+
+  gramadoirDirectObservable(
+    input: string,
+    language: 'en' | 'ga'): Observable<any>
+  {
+    return this.http.post(
+        this.gramadoirUrl,
+        this.gramadoirXWwwFormUrlencodedRequestData(input, language),
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          }
+        });
+  }
+
+  /*
+  * Get grammar tag data from an gramadoir
+  */
   getGramadoirTags(id: string) : Observable<any> {
     return Observable.create((observer: Observer<any>) => {
       this.storyService.gramadoir(id).subscribe((res) => {

--- a/ngapp/src/app/grammar.service.ts
+++ b/ngapp/src/app/grammar.service.ts
@@ -23,6 +23,10 @@ export type GramadoirTag = {
   errorlength: string;
 };
 
+const GRAMADOIR_RULE_ID_VALUES = ['CAIGHDEAN', 'default'] as const; // Add more valid types here
+// Makes a union type using the values from the array above, see: https://www.typescriptlang.org/docs/handbook/2/indexeda
+export type GramadoirRuleId = typeof GRAMADOIR_RULE_ID_VALUES[number];
+
 @Injectable({
   providedIn: 'root'
 })
@@ -38,6 +42,14 @@ export class GrammarService {
     private storyService: StoryService,
     private http: HttpClient,
   ) { }
+
+  string2GramadoirRuleId = (str: string): GramadoirRuleId => 
+    GRAMADOIR_RULE_ID_VALUES.find(validType => str === validType) || 'default';
+
+  userFriendlyGramadoirMessage: {[ruleId: string]: string} = {
+    'CAIGHDEAN': 'non-standard usage',
+    // Add more messages here
+  };
 
   /*
   * Set grammar and vowel tags of TagSet object

--- a/ngapp/src/app/grammar.service.ts
+++ b/ngapp/src/app/grammar.service.ts
@@ -46,8 +46,8 @@ export class GrammarService {
   string2GramadoirRuleId = (str: string): GramadoirRuleId => 
     GRAMADOIR_RULE_ID_VALUES.find(validType => str === validType) || 'default';
 
-  userFriendlyGramadoirMessage: {[ruleId: string]: string} = {
-    'CAIGHDEAN': 'non-standard usage',
+  userFriendlyGramadoirMessage: {[ruleId: string]: { en: string; ga: string; } } = {
+    CAIGHDEAN: {en: 'non-standard usage', ga: 'TODO'}
     // Add more messages here
   };
 

--- a/ngapp/src/app/story.service.ts
+++ b/ngapp/src/app/story.service.ts
@@ -108,6 +108,7 @@ export class StoryService {
   gramadoir(id: string) : Observable<any> {
     return this.http.get(this.baseUrl + 'gramadoir/' + id + '/' + this.ts.l.iso_code);
   }
+
   
   synthesiseObject(storyObject: Story) : Observable<any> {
     return this.http.post(this.baseUrl + 'synthesiseObject/', {story: storyObject});

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.css
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.css
@@ -347,14 +347,6 @@ background-color: lightblue;
     align-items: center;
 }
 
-.grammarTag > .grammarMessage {
-    visibility: hidden;
-}
-
-.grammarTag:hover > .grammarMessage {
-    visibility: visible;
-}
-
 .custom-tooltip::before {
     content: none !important;
 }
@@ -366,20 +358,14 @@ span[data-gramadoir-tag] {
 }
 
 span[data-gramadoir-tag="default"] {
-    background-color: #68b6fa; /* light blue */
-}
-
-span[data-gramadoir-tag="seimhiu"] {
-    background-color: #64b678;
-}
-
-span[data-gramadoir-tag="uru"] {
-    background-color: #9164b6;
+    background-color: #aed9ff; /* light blue */
 }
 
 span[data-gramadoir-tag="CAIGHDEAN"] {
-    background-color: #ffce38; /* yellow */
+    background-color: #ffdc71; /* yellow */
 }
+
+/* Add more here */
 
 .selectErrorCheckbox {
   display: flex;

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.css
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.css
@@ -361,14 +361,24 @@ background-color: lightblue;
 
 /* Gramadoir error tag colour coding */
 
+span[data-gramadoir-tag] {
+  border-radius: 4px;
+}
+
+span[data-gramadoir-tag="default"] {
+    background-color: #68b6fa; /* light blue */
+}
+
 span[data-gramadoir-tag="seimhiu"] {
     background-color: #64b678;
-    border-radius: 4px;
 }
 
 span[data-gramadoir-tag="uru"] {
     background-color: #9164b6;
-    border-radius: 4px;
+}
+
+span[data-gramadoir-tag="CAIGHDEAN"] {
+    background-color: #ffce38; /* yellow */
 }
 
 .selectErrorCheckbox {

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.html
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.html
@@ -101,6 +101,10 @@
           (click)="this.dontToggle=true; displayGrammarErrors()">
           simulate gramadoir
         </div>
+        <div *ngIf="showOptions" class="optionsBtn optionsPopupBtn"
+          (click)="this.dontToggle=true; getLines()">
+          get lines
+        </div>
       </div>
     </div>
 

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.html
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.html
@@ -102,6 +102,10 @@
           simulate gramadoir
         </div>
         <div *ngIf="showOptions" class="optionsBtn optionsPopupBtn"
+          (click)="this.dontToggle=true; clearHighlights()">
+          clear highlights
+        </div>
+        <div *ngIf="showOptions" class="optionsBtn optionsPopupBtn"
           (click)="this.dontToggle=true; getLines()">
           get lines
         </div>

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.html
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.html
@@ -102,10 +102,6 @@
           simulate gramadoir
         </div>
         <div *ngIf="showOptions" class="optionsBtn optionsPopupBtn"
-          (click)="this.dontToggle=true; clearHighlights()">
-          clear highlights
-        </div>
-        <div *ngIf="showOptions" class="optionsBtn optionsPopupBtn"
           (click)="this.dontToggle=true; getLines()">
           get lines
         </div>
@@ -124,7 +120,7 @@
           [preserveWhitespace]="true"
           [(ngModel)]="story.htmlText" 
           (onContentChanged)="storyEdited($event.text); getWordCount($event.text)"
-          (onEditorCreated)="createdQuill($event)"
+          (onEditorCreated)="quillEditor = $event"
         >
         </quill-editor>
          

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.ts
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.ts
@@ -23,6 +23,7 @@ import {
   GrammarTag,
   TagSet,
   GramadoirTag,
+  GramadoirRuleId,
 } from '../../grammar.service';
 
 import { typeWithParameters } from '@angular/compiler/src/render3/util';
@@ -41,13 +42,9 @@ Quill.register(gramadoirTag);
 type QuillHighlightTag = {
   start: number;
   length: number;
-  type: QuillHighlightType;
+  type: GramadoirRuleId;
   message: string;
 };
-
-const QUILL_HIGHLIGHT_TYPE_VALUES = ['CAIGHDEAN', 'default'] as const; // Add more valid types here
-// Makes a union type using the values from the array above, see: https://www.typescriptlang.org/docs/handbook/2/indexeda
-type QuillHighlightType = typeof QUILL_HIGHLIGHT_TYPE_VALUES[number];
 
 const Tooltip = Quill.import('ui/tooltip');
 
@@ -199,18 +196,6 @@ export class DashboardComponent implements OnInit {
     });
   }
 
-  createdQuill(quillEditorInstance) {
-    this.quillEditor = quillEditorInstance;
-  }
-
-  getQuillHighlightTypeFromRuleId = (ruleId: string): QuillHighlightType => 
-    QUILL_HIGHLIGHT_TYPE_VALUES.find(validType => ruleId === validType) || 'default';
-
-  getUserFriendlyGramadoirMessage: {[type: string]: string} = {
-    'CAIGHDEAN': 'non-standard usage'
-    // Add more messages here
-  }
-
   async displayGrammarErrors() {
     if (!this.quillEditor) return;
 
@@ -230,7 +215,7 @@ export class DashboardComponent implements OnInit {
                 ({
                   start: + tag.fromx,
                   length: + tag.tox + 1 - tag.fromx,
-                  type: this.getQuillHighlightTypeFromRuleId(tag.ruleId),
+                  type: this.grammar.string2GramadoirRuleId(tag.ruleId),
                   message: tag.msg,
                 }) as QuillHighlightTag
               )
@@ -253,7 +238,7 @@ export class DashboardComponent implements OnInit {
       const tooltip = new Tooltip(this.quillEditor);
       tooltip.root.classList.add('custom-tooltip');
       tooltip.root.innerText =
-        this.getUserFriendlyGramadoirMessage[error.type] || error.message; // Prefer user friendly message
+        this.grammar.userFriendlyGramadoirMessage[error.type] || error.message; // Prefer user friendly message
 
       // Add hover UI logic to the grammar error span element
       tagElem.addEventListener('mouseover', () => {

--- a/ngapp/src/app/student-components/dashboard/dashboard.component.ts
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.ts
@@ -33,9 +33,13 @@ import { ClassroomService } from '../../classroom.service';
 import Quill from 'quill';
 
 const Parchment = Quill.import('parchment');
-const gramadoirTag = new Parchment.Attributor.Attribute('gramadoir-tag', 'data-gramadoir-tag', { 
-  scope: Parchment.Scope.INLINE
-});
+const gramadoirTag =
+  new Parchment.Attributor.Attribute(
+    'gramadoir-tag',
+    'data-gramadoir-tag', {
+      scope: Parchment.Scope.INLINE
+    });
+
 Quill.register(gramadoirTag);
 
 
@@ -196,11 +200,20 @@ export class DashboardComponent implements OnInit {
     });
   }
 
+  clearAllGramadoirTags() {
+    this.quillEditor.formatText(
+      0, // from the very beginning of the text
+      this.quillEditor.getLength(), // to the very end of the text
+      {'gramadoir-tag': null} // delete all gramadoir-tag's on the parchment
+    );
+  }
+
   async displayGrammarErrors() {
-    if (!this.quillEditor) return;
+    if (!this.quillEditor) { return; }  // my tslint server keeps
+                                        // asking me to brace these guys
 
     // Clear existing highlights
-    this.quillEditor.formatText(0, this.quillEditor.getLength(), {'gramadoir-tag': null});
+    this.clearAllGramadoirTags();
 
     // Imaginary array of grammar checker errors (the API response)
     // We probably want to have these stored as a local variable
@@ -208,10 +221,13 @@ export class DashboardComponent implements OnInit {
     // type their strories.
     const grammarCheckerErrors =
       await this.grammar
-          .gramadoirDirectObservable(this.story.text.replace(/\n/g, ' '), 'en')
+          .gramadoirDirectObservable(
+            this.story.text.replace(/\n/g, ' '),  // convert text to single line
+                                                  // (no paragraphs/new lines)
+            this.ts.l.iso_code)
           .pipe(
-            map((tagData: GramadoirTag[]) => 
-              tagData.map(tag => 
+            map((tagData: GramadoirTag[]) =>
+              tagData.map(tag =>
                 ({
                   start: + tag.fromx,
                   length: + tag.tox + 1 - tag.fromx,


### PR DESCRIPTION
got some gramadoir functions from the
`grammar_checker_refactor` branch
transformed the output as a new type, `QuillHighlightTag`

these `QuillHighlightTag`s are used to make visible tags
with popup explainers (i.e. the gramadoir `msg`)