### PR TITLE
App component notifications drop down opens stories in a new tab.

### DIFF
--- a/ngapp/src/app/app.component.html
+++ b/ngapp/src/app/app.component.html
@@ -90,9 +90,14 @@
     <div *ngIf="notificationsShown && (storiesForNotifications.length > 0 || messagesForNotifications.length > 0)" class="optionsPopupOld notifcationPopup">
       <div *ngIf="storiesForNotifications.length > 0" class="notificationsHeader">{{ts.l.new_feedback}}</div>
       <div class="notificationsBody">
-        <div *ngFor="let story of storiesForNotifications" class="notificationCard" (click)="goToStory(story._id)">
-          {{story.title}}
-        </div>
+        <a
+          *ngFor="let story of storiesForNotifications"
+          class="notificationCard"
+          target="_blank"
+          routerLink="{{'/dashboard/' + story._id}}"
+          >
+            {{story.title}}
+        </a>
       </div>
       <div class="notificationsHeader" *ngIf="notificationsShown && messagesForNotifications.length > 0">{{ts.l.new_messages}}</div>
       <div class="notificationsBody">


### PR DESCRIPTION
**EDIT** actually both bugs described below are still present. The first happens when you try to click on a story with notifications and the story you're currently on *hasn't been saved yet*. Additionally, clicking save doesn't actually bring you away to the new story you clicked on.

### bug 1 (deletes your stories)
So… I was trying to replicate the bug today where clicking to see a story with notifications would erase the contents of the story open when clicking, but *I could not replicate it*. The bug has disappeared.

### bug 2 (annoying! you have to hit refresh)
**EDIT** This is actually the bug that Maddie pointed out in the original issue #133 
In its place a *related but different bug has appeared*. Now, it seems, when you click to go to another story with notifications *while you have a different story open in the dashboard*, the url in your address bar will change, but your story will not appear until you hit refresh. Why? I have not clue.

This PR offers a solution which I think ought to make both of those bugs impossible.

The solution is to open the story in a new tab.

## Implementation

Rather than using a (click) directive and
function for routing to the story the
tag is now an <a> tag with target="_blank" (open in a new tab)
and routerLink="{{'/dashboard/' + story._id}}".

## Pros:
* There is no chance of someone losing
their work by clicking one of these links because
their tab with potentially unsaved work is left
open.
* The code is simpler

## Cons:
* More tabs being open might be confusing.
* It opens in a new tab no matter what,
even if they are already looking at that story.