### PR TITLE
Update project setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,42 +49,57 @@ all the required dependencies installed you should now
 be able to view the site at `http://localhost:4200`
 
 ### Manually starting all services
-1a) (Using global installation of Angular) In the project root folder, /an-scealai, run the following command to start the Frontend server:
-```bash
-$ ng serve
+#### Frontend
+1) From the root directory, `/an-scealai`, navigate to the `ngapp` directory, which contains the frontend project:
 ```
-1b) (Using local installation of Angular):
-```bash
-$ npm start
+$ cd ngapp
 ```
+2) Start the frontend app:
 
-2) Run the Mongo Daemon with the following command:
+*  a) (Using global installation of Angular):
+  ```bash
+  $ ng serve
+  ```
+*  b) (Using local installation of Angular):
+  ```bash
+  $ npm start
+```
+#### Database
+3) Run the Mongo Daemon with the following command:
 ```bash
 $ mongod
 ```
-If this doesn't work you may need root priveleges:
+* If this doesn't work you may need root priveleges:
 ```bash
 $ sudo mongod
 ```
-If it still doesn't work, you may need to create a folder called `/data/db` or `C:\data\db` on Windows.
-This is where MongoDB will store files.
+* If it still doesn't work, you may need to create a folder called `/data/db` or `C:\data\db` on Windows. This is where MongoDB will store files.
 ```bash
 $ mkdir /data
 $ mkdir /data/db
+$ sudo mongod --dbpath=/path/to/data/db/folder
 ```
-
-3) In the API folder, /an-scealai/api, run the following command to start the Backend server:
+(See https://stackoverflow.com/a/61423909 for more)
+#### Backend
+5) Add [sendinblue](https://www.sendinblue.com/) authentication details to `/an-scealai/api/sendinblue.json`. This allows the backend to send verification emails for user registration. [See this tutorial for more information](https://schadokar.dev/posts/how-to-send-email-in-nodejs/).
+```javascript
+{
+  "user": "<username>",
+  "pass": "<password>"
+}
+```
+6) In the API folder, `/an-scealai/api`, run the following command to start the Backend server:
 ```bash
 $ cd api/
 $ nodemon server.js
 ```
 
-4) Navigate to http://localhost:4200/.
+7) Navigate to http://localhost:4200/.
 
 
 # CHANGE LOG
 
 ## v1.0.8
-bugfix: in `ngapp/src/app/engagement.service.ts` Neimhin mistakenly
-used a `for in` instead of a `for of` loop to serialize
+bugfix: in `ngapp/src/app/engagement.service.ts`
+`for in` was used instead of a `for of` loop to serialize
 grammar tag data, resulting in no data being sent and inserted into the database.

--- a/README.md
+++ b/README.md
@@ -81,20 +81,20 @@ $ sudo mongod --dbpath=/path/to/data/db/folder
 ```
 (See https://stackoverflow.com/a/61423909 for more)
 #### Backend
-5) Add [sendinblue](https://www.sendinblue.com/) authentication details to `/an-scealai/api/sendinblue.json`. This allows the backend to send verification emails for user registration. [See this tutorial for more information](https://schadokar.dev/posts/how-to-send-email-in-nodejs/).
+4) Add the following [sendinblue](https://www.sendinblue.com/) authentication details to `/an-scealai/api/sendinblue.json`. This allows the backend to send verification emails for user registration. [See this tutorial for more information](https://schadokar.dev/posts/how-to-send-email-in-nodejs/).
 ```javascript
 {
   "user": "<username>",
   "pass": "<password>"
 }
 ```
-6) In the API folder, `/an-scealai/api`, run the following command to start the Backend server:
+5) In the API folder, `/an-scealai/api`, run the following command to start the Backend server:
 ```bash
 $ cd api/
 $ nodemon server.js
 ```
 
-7) Navigate to http://localhost:4200/.
+6) Navigate to http://localhost:4200/.
 
 
 # CHANGE LOG


### PR DESCRIPTION
* I tried to set up a fresh build locally and realised that the current setup instructions aren't up-to-date; we've added some new features since it was written. 
* This PR just adds a fix for a mongodb bug I ran into (due to updating my OS to MacOS Catalina, as far as I can tell), and adds an extra step for the sendinblue auth details, which are necessary for the backend to start.