### PR TITLE
Paginate admin user search

### DIFF
--- a/api/endpoints_functions/user/getUserCount.js
+++ b/api/endpoints_functions/user/getUserCount.js
@@ -1,0 +1,20 @@
+const User = require('../../models/user');
+
+/**
+ * Returns the total number of users on the DB, as well as individual
+ * counts of each user role.
+ */
+async function getUserCount(req, res) {
+  const total = await User.where({}).countDocuments();
+  const student = await User.where({role: 'STUDENT'}).countDocuments();
+  const teacher = await User.where({role: 'TEACHER'}).countDocuments();
+  const admin = await User.where({role: 'ADMIN'}).countDocuments();
+  return res.status(200).json({
+      total: total,
+      student: student,
+      teacher: teacher,
+      admin: admin
+  });
+}
+
+module.exports = getUserCount;

--- a/api/endpoints_functions/user/searchUser.js
+++ b/api/endpoints_functions/user/searchUser.js
@@ -9,6 +9,7 @@ const {API404Error, API400Error} = require('../../utils/APIError');
 async function searchUser(req, res) {
   // default values for req body
   reqBody = {
+    searchString: req.body.searchString ? req.body.searchString : '',
     limit: req.body.limit ? req.body.limit : 20,
     currentPage: req.body.currentPage ? req.body.currentPage : 0,
     roles: req.body.roles ? req.body.roles : [
@@ -33,7 +34,7 @@ async function searchUser(req, res) {
   }
 
   // find username containing searchRegex as substring
-  const searchRegex = new RegExp(req.params.searchString, 'i'); // i for case insensitive
+  const searchRegex = new RegExp(reqBody.searchString, 'i'); // i for case insensitive
   const mongoQuery = {
     username: {$regex: searchRegex},
     role: {$in: reqBody.roles}
@@ -46,7 +47,7 @@ async function searchUser(req, res) {
   const userCount = await User.where(mongoQuery).countDocuments()
 
   if (!users) {
-    throw new API404Error(`No users with substring ${req.params.searchString} were found.`);
+    throw new API404Error(`No users matching the search string were found.`);
   }
   console.dir(users);
   return res.status(200).json({users: users, count: userCount});

--- a/api/globalConfig.json
+++ b/api/globalConfig.json
@@ -1,1 +1,1 @@
-{"mongoUri":"mongodb://127.0.0.1:52822/"}
+{"mongoUri":"mongodb://127.0.0.1:59718/"}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "api",
       "version": "1.0.8",
       "license": "ISC",
       "dependencies": {

--- a/api/routes/user.route.js
+++ b/api/routes/user.route.js
@@ -37,9 +37,13 @@ let userRoutes;
   // ENDPOINT HANDLERS
   const searchUser =
     require('../endpoints_functions/user/searchUser');
+  const getUserCount =
+    require('../endpoints_functions/user/getUserCount');
 
     userRoutes = makeEndpoints({
-      get: {},
+      get: {
+        '/count': getUserCount,
+      },
       post: {
         '/searchUser': searchUser,
       }

--- a/api/routes/user.route.js
+++ b/api/routes/user.route.js
@@ -41,7 +41,7 @@ let userRoutes;
     userRoutes = makeEndpoints({
       get: {},
       post: {
-        '/searchUser/:searchString': searchUser,
+        '/searchUser': searchUser,
       }
     });
 })();

--- a/api/routes/user.route.test.js
+++ b/api/routes/user.route.test.js
@@ -18,7 +18,7 @@ describe('user routes', () => {
         ]);
 
         const SEARCH_STRING = 'a'
-        const res = await request.post(`/user/searchUser/${SEARCH_STRING}`);
+        const res = await request.post(`/user/searchUser/`, {searchString: SEARCH_STRING});
   
         expect(res.status).toBe(200);
         expect(res.body.users[0].username).toBe(users[0].username);
@@ -34,9 +34,12 @@ describe('user routes', () => {
         const SEARCH_STRING = 'a'
         const LIMIT = 2
         const res = await request.post(
-          `/user/searchUser/${SEARCH_STRING}/`,
+          `/user/searchUser`,
         ).send(
-          {limit: LIMIT}
+          {
+            searchString: SEARCH_STRING,
+            limit: LIMIT
+          }
         );
 
         expect(res.status).toBe(200);
@@ -54,9 +57,10 @@ describe('user routes', () => {
         const LIMIT = 1
         const PAGE_NUMBER = 1
         const res = await request.post(
-          `/user/searchUser/${SEARCH_STRING}`
+          `/user/searchUser`
         ).send(
           {
+            searchString: SEARCH_STRING,
             limit: LIMIT,
             currentPage: PAGE_NUMBER
           }
@@ -77,9 +81,10 @@ describe('user routes', () => {
 
       const SEARCH_STRING = 'a'
       const res = await request.post(
-        `/user/searchUser/${SEARCH_STRING}`
+        `/user/searchUser`
       ).send(
         {
+          searchString: SEARCH_STRING,
           roles: ['STUDENT', 'ADMIN']
         }
       );
@@ -99,8 +104,13 @@ describe('user routes', () => {
       const SEARCH_STRING = 'a'
       const LIMIT = 1
       const res = await request.post(
-        `/user/searchUser/${SEARCH_STRING}`
-      ).send({limit: LIMIT});
+        `/user/searchUser`
+      ).send(
+        {
+          searchString: SEARCH_STRING,
+          limit: LIMIT
+        }
+      );
 
       expect(res.status).toBe(200);
       // limited to 1 result, but total count is 3, 

--- a/ngapp/package-lock.json
+++ b/ngapp/package-lock.json
@@ -12750,6 +12750,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/ngapp/src/app/admin-components/find-user/find-user.component.css
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.css
@@ -22,7 +22,18 @@
     padding: 10px;
     padding-bottom: 0px;
     height: 500px;
-    overflow-y: scroll;
+    
+}
+
+.resultContainer {
+  padding: 10px;
+  padding-bottom: 0px;
+  -moz-box-shadow:    inset 0 0 7px #000000b6;
+  -webkit-box-shadow: inset 0 0 7px #000000b6;
+  box-shadow:         inset 0 0 7px #000000b6;
+  border-radius: 5px;
+  overflow-y: scroll;
+  max-height: 250px;
 }
 
 .resultCard {

--- a/ngapp/src/app/admin-components/find-user/find-user.component.css
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.css
@@ -7,7 +7,7 @@
 
 .searchContainer {
     background: #d1d1d1;
-    width: 50%;
+    width: 60%;
     border-radius: 4px;
 }
 

--- a/ngapp/src/app/admin-components/find-user/find-user.component.html
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.html
@@ -41,7 +41,7 @@
       
       <div>
         <button (click)="goPrevPage()">&lt;</button>
-        Page {{currentPage}} / {{getPageCount()}}
+        Page {{currentPage+1}} / {{getPageCount()+1}}
         <button (click)="goNextPage()">&gt;</button>
       </div>
 

--- a/ngapp/src/app/admin-components/find-user/find-user.component.html
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.html
@@ -1,7 +1,7 @@
 <div class='container'>
   <div class='searchContainer'>
     <div class='searchHeader'>
-      {{ts.l.all_users}}
+      {{ts.l.all_users}} ({{userCount}})
     </div>
     
     <!-- Loading panel -->

--- a/ngapp/src/app/admin-components/find-user/find-user.component.html
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.html
@@ -23,45 +23,25 @@
         <div>
           <div class="form-group">
             <label for="search-text">{{ts.l.search_user}}</label>
-            <input type="text" class="form-control" id="search-text" aria-describedby="search-text" 
-              [(ngModel)]="searchText" placeholder="Enter user to search" 
-              autofocus>
+            <input
+              type="text" 
+              class="form-control" 
+              id="search-text" 
+              aria-describedby="search-text"
+              [ngModel]='searchText'
+              (ngModelChange)='searchModelChanged.next($event)' 
+              placeholder="Enter user to search"
+            >
           </div>
         </div>
       </div>
       
       <!-- List of users -->
       {{ts.l.results}}
-      <div *ngIf="!students && !teachers && !admins">
-        <div class='resultCard' routerLink="../user/{{user._id}}" *ngFor="let user of userResults | appFilter: searchText" >
-          <div appHighlight [searchedWord]="searchText" [content]="user.username" [classToApply]="'font-weight-bold'" [setTitle]="'true'">
-          {{user.username}}</div>
-          <div>{{user.role}}</div>
-        </div>
-      </div>
-      
-      <div *ngIf="students">
-        <div class='resultCard' routerLink="../user/{{user._id}}" *ngFor="let user of allStudents | appFilter: searchText">
-          <div appHighlight [searchedWord]="searchText" [content]="user.username" [classToApply]="'font-weight-bold'" [setTitle]="'true'">
-          {{user.username}}</div>
-          <div>{{user.role}}</div>
-        </div>
-      </div>
-      
-      <div *ngIf="teachers">
-        <div class='resultCard' routerLink="../user/{{user._id}}" *ngFor="let user of allTeachers | appFilter: searchText">
-          <div appHighlight [searchedWord]="searchText" [content]="user.username" [classToApply]="'font-weight-bold'" [setTitle]="'true'">
-          {{user.username}}</div>
-          <div>{{user.role}}</div>
-        </div>
-      </div>
-      
-      <div *ngIf="admins">
-        <div class='resultCard' routerLink="../user/{{user._id}}" *ngFor="let user of allAdmins | appFilter: searchText">
-          <div appHighlight [searchedWord]="searchText" [content]="user.username" [classToApply]="'font-weight-bold'" [setTitle]="'true'">
-          {{user.username}}</div>
-          <div>{{user.role}}</div>
-        </div>
+      <div class='resultCard' routerLink="../user/{{user._id}}" *ngFor="let user of userResults" >
+        <div appHighlight [searchedWord]="searchText" [content]="user.username" [classToApply]="'font-weight-bold'" [setTitle]="'true'">
+        {{user.username}}</div>
+        <div>{{user.role}}</div>
       </div>
     </div>
   </div>

--- a/ngapp/src/app/admin-components/find-user/find-user.component.html
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.html
@@ -1,7 +1,7 @@
 <div class='container'>
   <div class='searchContainer'>
     <div class='searchHeader'>
-      {{ts.l.all_users}} ({{numberOfUsers}})
+      {{ts.l.all_users}}
     </div>
     
     <!-- Loading panel -->
@@ -14,30 +14,39 @@
     <div *ngIf="dataLoaded" class='searchResultsContainer'>
       <div class='filter'>
         <div> {{ts.l.filter_by}}: </div>
-        <div class="checkbox-line"><input type="checkbox"[(ngModel)]="students"/> {{ts.l.students}} ({{allStudents.length}})</div>
-        <div class="checkbox-line"><input type="checkbox"[(ngModel)]="teachers"/> {{ts.l.teachers}} ({{allTeachers.length}})</div>
-        <div class="checkbox-line"><input type="checkbox"[(ngModel)]="admins"/> {{ts.l.admins}} ({{allAdmins.length}})</div>  
-      </div> 
+        <div class="checkbox-line"><input type="checkbox" [(ngModel)]="roleFilter.STUDENT"/> {{ts.l.students}}</div>
+        <div class="checkbox-line"><input type="checkbox" [(ngModel)]="roleFilter.TEACHER"/> {{ts.l.teachers}}</div>
+        <div class="checkbox-line"><input type="checkbox" [(ngModel)]="roleFilter.ADMIN"/> {{ts.l.admins}}</div>  
+      </div>
       <!-- Search bar -->
       <div role="main">
         <div>
           <div class="form-group">
             <label for="search-text">{{ts.l.search_user}}</label>
-            <input
-              type="text" 
-              class="form-control" 
-              id="search-text" 
-              aria-describedby="search-text"
-              [ngModel]='searchText'
-              (ngModelChange)='searchModelChanged.next($event)' 
-              placeholder="Enter user to search"
-            >
+            <div style="display: flex">
+              <input
+                type="text" 
+                class="form-control" 
+                id="search-text" 
+                aria-describedby="search-text"
+                [ngModel]='searchText'
+                (ngModelChange)='searchModelChanged.next($event)' 
+                placeholder="Enter user to search"
+              >
+              <button (click)="currentPage = 0; searchUsers();">Search</button>
+            </div>
           </div>
         </div>
       </div>
       
+      <div>
+        <button (click)="goPrevPage()">&lt;</button>
+        Page {{currentPage}} / {{getPageCount()}}
+        <button (click)="goNextPage()">&gt;</button>
+      </div>
+
       <!-- List of users -->
-      {{ts.l.results}}
+      <div style="margin: 5px;">{{ts.l.results}} ({{resultCount}})</div>
       <div class='resultCard' routerLink="../user/{{user._id}}" *ngFor="let user of userResults" >
         <div appHighlight [searchedWord]="searchText" [content]="user.username" [classToApply]="'font-weight-bold'" [setTitle]="'true'">
         {{user.username}}</div>

--- a/ngapp/src/app/admin-components/find-user/find-user.component.html
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.html
@@ -13,7 +13,7 @@
     <!-- Filter by role -->
     <div *ngIf="dataLoaded" class='searchResultsContainer'>
       <div class='filter'>
-        <div> {{ts.l.filter_by}}: </div>
+        <div> Include: </div>
         <div class="checkbox-line"><input type="checkbox" [(ngModel)]="roleFilter.STUDENT"/> {{ts.l.students}}</div>
         <div class="checkbox-line"><input type="checkbox" [(ngModel)]="roleFilter.TEACHER"/> {{ts.l.teachers}}</div>
         <div class="checkbox-line"><input type="checkbox" [(ngModel)]="roleFilter.ADMIN"/> {{ts.l.admins}}</div>  
@@ -47,10 +47,18 @@
 
       <!-- List of users -->
       <div style="margin: 5px;">{{ts.l.results}} ({{resultCount}})</div>
-      <div class='resultCard' routerLink="../user/{{user._id}}" *ngFor="let user of userResults" >
-        <div appHighlight [searchedWord]="searchText" [content]="user.username" [classToApply]="'font-weight-bold'" [setTitle]="'true'">
-        {{user.username}}</div>
-        <div>{{user.role}}</div>
+      <div class='resultContainer' *ngIf="resultCount > 0 && searchText">
+        <div class='resultCard' routerLink="../user/{{user._id}}" *ngFor="let user of userResults" >
+          <div appHighlight [searchedWord]="searchText" [content]="user.username" [classToApply]="'font-weight-bold'" [setTitle]="'true'">
+          {{user.username}}</div>
+          <div>{{user.role}}</div>
+        </div>
+      </div>
+      <div *ngIf="!searchText">
+        Type above to search for users.
+      </div>
+      <div *ngIf="searchText && resultCount == 0">
+        No usernames match the string entered above.
       </div>
     </div>
   </div>

--- a/ngapp/src/app/admin-components/find-user/find-user.component.ts
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.ts
@@ -41,7 +41,7 @@ export class FindUserComponent implements OnInit {
   numberOfUsers : number = 0;
   resultCount: number = 0;
   currentPage: number = 0;
-  LIMIT = 1;
+  LIMIT = 20;
   roleFilter = {
     'STUDENT': true,
     'TEACHER': true,

--- a/ngapp/src/app/admin-components/find-user/find-user.component.ts
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.ts
@@ -19,6 +19,7 @@ export class FindUserComponent implements OnInit {
   private searchModelChangeSubscription: Subscription;
 
   ngOnInit() {
+    this.userService.getUserCount().subscribe(res => this.userCount = res.total);
     this.searchModelChangeSubscription = this.searchModelChanged
       .pipe(
         debounceTime(1000),
@@ -34,6 +35,8 @@ export class FindUserComponent implements OnInit {
   ngOnDestroy() {
     this.searchModelChangeSubscription.unsubscribe();
   }
+
+  userCount: number = 0;
 
   // This array will store User objects to be displayed
   userResults : User[] = [];

--- a/ngapp/src/app/admin-components/find-user/find-user.component.ts
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.ts
@@ -52,7 +52,20 @@ export class FindUserComponent implements OnInit {
   }
   dataLoaded: boolean = true;
 
+  validSearchText() {
+    try {
+      new RegExp(this.searchText, 'i'); // i for case insensitive
+    }
+    catch (e) {
+      console.log('Caught error:', e);
+      alert("invalid regular expression");
+      return false;
+    }
+    return true;
+  }
+
   searchUsers() {
+    if (!this.validSearchText()) return;
     this.dataLoaded = false;
     this.userResults = [];
     const roles = Object.entries(this.roleFilter).filter(pair => pair[1]).map(pair => pair[0])
@@ -60,7 +73,7 @@ export class FindUserComponent implements OnInit {
       this.userResults = res.users.map(userData => new User().fromJSON(userData));
       this.resultCount = res.count;
       this.dataLoaded = true;
-    });
+      });
   }
 
   getPageCount(): number {

--- a/ngapp/src/app/admin-components/find-user/find-user.component.ts
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.ts
@@ -43,14 +43,15 @@ export class FindUserComponent implements OnInit {
   currentPage: number = 0;
   LIMIT = 1;
   roleFilter = {
-    'STUDENT': false,
-    'TEACHER': false,
-    'ADMIN': false,
+    'STUDENT': true,
+    'TEACHER': true,
+    'ADMIN': true,
   }
   dataLoaded: boolean = true;
 
   searchUsers() {
     this.dataLoaded = false;
+    this.userResults = [];
     const roles = Object.entries(this.roleFilter).filter(pair => pair[1]).map(pair => pair[0])
     this.userService.searchUser(this.searchText, this.currentPage, this.LIMIT, roles).subscribe((res: any) => {
       this.userResults = res.users.map(userData => new User().fromJSON(userData));
@@ -60,11 +61,12 @@ export class FindUserComponent implements OnInit {
   }
 
   getPageCount(): number {
-    return Math.floor(this.resultCount / this.LIMIT);
+    const pageCount = Math.floor(this.resultCount / this.LIMIT);
+    return pageCount > 0 ? pageCount - 1 : 0;
   }
 
   goNextPage() {
-    if (this.currentPage < this.getPageCount()) {
+    if (this.currentPage < this.getPageCount() - 1) {
       this.currentPage++;
       this.searchUsers();
     }

--- a/ngapp/src/app/admin-components/find-user/find-user.component.ts
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.ts
@@ -25,7 +25,9 @@ export class FindUserComponent implements OnInit {
         distinctUntilChanged()
       )
       .subscribe(searchString => {
-        this.searchUsers(searchString)
+        this.searchText = searchString;
+        this.currentPage = 0;
+        this.searchUsers();
       });
   }
 
@@ -37,20 +39,42 @@ export class FindUserComponent implements OnInit {
   userResults : User[] = [];
   
   numberOfUsers : number = 0;
-  students : boolean = false;
-  teachers : boolean = false;
-  admins : boolean = false;
-  allStudents : User[] = [];
-  allTeachers : User[] = [];
-  allAdmins: User[] = [];
+  resultCount: number = 0;
+  currentPage: number = 0;
+  LIMIT = 1;
+  roleFilter = {
+    'STUDENT': false,
+    'TEACHER': false,
+    'ADMIN': false,
+  }
   dataLoaded: boolean = true;
 
-  searchUsers(searchString: string) {
+  searchUsers() {
     this.dataLoaded = false;
-    this.userService.searchUser(searchString, 0, 2).subscribe((users: any) => {
-      this.userResults = users.map(userData => new User().fromJSON(userData));
+    const roles = Object.entries(this.roleFilter).filter(pair => pair[1]).map(pair => pair[0])
+    this.userService.searchUser(this.searchText, this.currentPage, this.LIMIT, roles).subscribe((res: any) => {
+      this.userResults = res.users.map(userData => new User().fromJSON(userData));
+      this.resultCount = res.count;
       this.dataLoaded = true;
     });
+  }
+
+  getPageCount(): number {
+    return Math.floor(this.resultCount / this.LIMIT);
+  }
+
+  goNextPage() {
+    if (this.currentPage < this.getPageCount()) {
+      this.currentPage++;
+      this.searchUsers();
+    }
+  }
+
+  goPrevPage() {
+    if (this.currentPage > 0) {
+      this.currentPage--;
+      this.searchUsers();
+    }
   }
   
   /*

--- a/ngapp/src/app/user.service.ts
+++ b/ngapp/src/app/user.service.ts
@@ -38,6 +38,10 @@ export class UserService {
     );
   }
 
+  getUserCount(): Observable<any> {
+    return this.http.get(this.baseUrl + 'count/');
+  }
+
   deleteUser(username: string): Observable<any> {
     return this.http.get(this.baseUrl + 'deleteUser/' + username);
   }

--- a/ngapp/src/app/user.service.ts
+++ b/ngapp/src/app/user.service.ts
@@ -26,21 +26,37 @@ export class UserService {
     return this.http.get(this.baseUrl + 'getAllUsers/');
   }
 
-  searchUser(searchString: string, pageNumber: number, limit: number): Observable<any> {
-    return of([
-      {
-        "_id": '12345',
-        "username": 'alice',
-        "role": 'STUDENT',
-        "language" : 'ga',
-      },
-      {
-        "_id": '67890',
-        "username": 'bob',
-        "role": 'TEACHER',
-        "language" : 'en',
-      },
-    ]);
+  searchUser(searchString: string, pageNumber: number, limit: number, roles: string[]): Observable<any> {
+    console.log(roles);
+    return of({
+      users: [
+        {
+          "_id": '12345',
+          "username": 'alice',
+          "role": 'STUDENT',
+          "language" : 'ga',
+        },
+        {
+          "_id": '67890',
+          "username": 'bob',
+          "role": 'TEACHER',
+          "language" : 'en',
+        },
+        {
+          "_id": '14525',
+          "username": 'carl',
+          "role": 'TEACHER',
+          "language" : 'en',
+        },
+        {
+          "_id": '19572',
+          "username": 'dearbhla',
+          "role": 'STUDENT',
+          "language" : 'ga',
+        },
+      ].slice(pageNumber * limit, (pageNumber * limit) + limit),
+      count: 4
+    });
   }
 
   deleteUser(username: string): Observable<any> {

--- a/ngapp/src/app/user.service.ts
+++ b/ngapp/src/app/user.service.ts
@@ -27,36 +27,15 @@ export class UserService {
   }
 
   searchUser(searchString: string, pageNumber: number, limit: number, roles: string[]): Observable<any> {
-    console.log(roles);
-    return of({
-      users: [
-        {
-          "_id": '12345',
-          "username": 'alice',
-          "role": 'STUDENT',
-          "language" : 'ga',
-        },
-        {
-          "_id": '67890',
-          "username": 'bob',
-          "role": 'TEACHER',
-          "language" : 'en',
-        },
-        {
-          "_id": '14525',
-          "username": 'carl',
-          "role": 'TEACHER',
-          "language" : 'en',
-        },
-        {
-          "_id": '19572',
-          "username": 'dearbhla',
-          "role": 'STUDENT',
-          "language" : 'ga',
-        },
-      ].slice(pageNumber * limit, (pageNumber * limit) + limit),
-      count: 4
-    });
+    return this.http.post(
+      this.baseUrl + `searchUser/`,
+      {
+        searchString: searchString,
+        limit: limit,
+        currentPage: pageNumber,
+        roles: roles
+      }
+    );
   }
 
   deleteUser(username: string): Observable<any> {

--- a/ngapp/src/app/user.service.ts
+++ b/ngapp/src/app/user.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 // import { User } from './user';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { User } from './user'
 import config from '../abairconfig.json';
 
 @Injectable({
@@ -23,6 +24,23 @@ export class UserService {
 
   getAllUsers(): Observable<any> {
     return this.http.get(this.baseUrl + 'getAllUsers/');
+  }
+
+  searchUser(searchString: string, pageNumber: number, limit: number): Observable<any> {
+    return of([
+      {
+        "_id": '12345',
+        "username": 'alice',
+        "role": 'STUDENT',
+        "language" : 'ga',
+      },
+      {
+        "_id": '67890',
+        "username": 'bob',
+        "role": 'TEACHER',
+        "language" : 'en',
+      },
+    ]);
   }
 
   deleteUser(username: string): Observable<any> {


### PR DESCRIPTION
Hopefully this fixes #172, CC @NeasaNi 

* Added new user search endpoint (see: #173) that will grab sets of 20 users from the database at a time. Filtering by user role (teacher / student / admin) also happens on the backend now.
* ~~Note that we're no longer displaying a total user count here -- I think including this in a more general 'analytics' admin page would make more sense. I'm hopeful that [mongoose countDocuments()](https://mongoosejs.com/docs/api.html#query_Query-countDocuments) would let us do this without crashing the DB.~~ See below.
* It would probably be smart to test this on the QA site by making a database with a large amount of fake users (like >10k) and seeing if this method manages not to crash the DB.
* The UI should now display pages of user results, like google search results, which can be traversed using the left / right arrow buttons:
![image](https://user-images.githubusercontent.com/34962541/149178660-6bc97ae1-9c3a-4f7b-b86a-58f274888aae.png)

