### PR TITLE
Validate RegExp before sending search string to backend for find-user admin panel

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "api",
       "version": "1.0.8",
       "license": "ISC",
       "dependencies": {

--- a/ngapp/package-lock.json
+++ b/ngapp/package-lock.json
@@ -12750,6 +12750,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/ngapp/src/app/admin-components/find-user/find-user.component.ts
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.ts
@@ -27,7 +27,9 @@ export class FindUserComponent implements OnInit {
       .subscribe(searchString => {
         this.searchText = searchString;
         this.currentPage = 0;
-        this.searchUsers();
+        if (this.validSearchText()) {
+          this.searchUsers();
+        }
       });
   }
 
@@ -49,6 +51,18 @@ export class FindUserComponent implements OnInit {
   }
   dataLoaded: boolean = true;
 
+  validSearchText() {
+    try {
+      new RegExp(this.searchText, 'i'); // i for case insensitive
+    }
+    catch (e) {
+      console.log('Caught error:', e);
+      alert("invalid regular expression");
+      return false;
+    }
+    return true;
+  }
+
   searchUsers() {
     this.dataLoaded = false;
     this.userResults = [];
@@ -57,7 +71,7 @@ export class FindUserComponent implements OnInit {
       this.userResults = res.users.map(userData => new User().fromJSON(userData));
       this.resultCount = res.count;
       this.dataLoaded = true;
-    });
+      });
   }
 
   getPageCount(): number {

--- a/ngapp/src/app/admin-components/find-user/find-user.component.ts
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.ts
@@ -64,6 +64,7 @@ export class FindUserComponent implements OnInit {
   }
 
   searchUsers() {
+    if (!validTextSearch()) return;
     this.dataLoaded = false;
     this.userResults = [];
     const roles = Object.entries(this.roleFilter).filter(pair => pair[1]).map(pair => pair[0])

--- a/ngapp/src/app/admin-components/find-user/find-user.component.ts
+++ b/ngapp/src/app/admin-components/find-user/find-user.component.ts
@@ -27,9 +27,7 @@ export class FindUserComponent implements OnInit {
       .subscribe(searchString => {
         this.searchText = searchString;
         this.currentPage = 0;
-        if (this.validSearchText()) {
-          this.searchUsers();
-        }
+        this.searchUsers();
       });
   }
 
@@ -64,7 +62,7 @@ export class FindUserComponent implements OnInit {
   }
 
   searchUsers() {
-    if (!validTextSearch()) return;
+    if (!this.validSearchText()) return;
     this.dataLoaded = false;
     this.userResults = [];
     const roles = Object.entries(this.roleFilter).filter(pair => pair[1]).map(pair => pair[0])


### PR DESCRIPTION
Here's a solution to the error arising from sending invalid RegExp constructor arguments to the backend for searching users.