### PR TITLE
Moved teacher audio feedback popup

### DIFF
--- a/ngapp/src/app/teacher-components/teacher-story/teacher-story.component.css
+++ b/ngapp/src/app/teacher-components/teacher-story/teacher-story.component.css
@@ -223,8 +223,10 @@
     background-color: rgba(0, 0, 0, 0.5);
     text-align: center;
     display: flex;
-    align-items: center;
-    justify-content: center;
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding-right: 25px;
+    padding-bottom: 25px;
 }
 
 .modalContent {


### PR DESCRIPTION
See #180 

* Moves the popup so that it no longer covers story information, see:
![image](https://user-images.githubusercontent.com/34962541/153868498-a0aefbe0-787e-4a93-851d-835ab525a3d6.png)
