### PR TITLE
logger logs (err.stack || err)

### DIFF
--- a/api/utils/errorHandler.js
+++ b/api/utils/errorHandler.js
@@ -15,7 +15,7 @@ const logger = require('../logger');
 function errorHandler(err, req, res, next) {
   console.dir(err);
 
-  logger.alert({errorHandler: {err}});
+  logger.alert(err.stack || err);
 
   if (!(err instanceof APIError)) {
       return res.send(err);


### PR DESCRIPTION
logging `Error`s directly with winston does not work. Instead log err.stack where possible.