### PR TITLE
example script to collate grammar errors by version for a story

### DIFF
--- a/api/mongo_scripts/gramadoirViewExample.js
+++ b/api/mongo_scripts/gramadoirViewExample.js
@@ -8,10 +8,7 @@
     cursor.toArray((err,docs)=>{
       console.error(err);
       docs.forEach(d=>{
-        d.gramadoirHistory.forEach(t=>{
-          console.log(t.text);
-          console.log(t.grammarTags);
-        });
+        console.log(d);
       });
       db.collection(viewName).drop();
       resolve();

--- a/api/mongo_scripts/gramadoirViewExample.js
+++ b/api/mongo_scripts/gramadoirViewExample.js
@@ -1,0 +1,20 @@
+;(async () => {
+  return new Promise(async (resolve) => {
+    const viewName = ''+Date.now();
+    await require('../utils/gramadoirView')(viewName);
+    const mongoose = require('mongoose');
+    const { db } = mongoose.connection;
+    const cursor = db.collection(viewName).find();
+    cursor.toArray((err,docs)=>{
+      console.error(err);
+      docs.forEach(d=>{
+        d.gramadoirHistory.forEach(t=>{
+          console.log(t.text);
+          console.log(t.grammarTags);
+        });
+      });
+      db.collection(viewName).drop();
+      resolve();
+    });
+  });
+})();

--- a/api/utils/gramadoirView.js
+++ b/api/utils/gramadoirView.js
@@ -24,16 +24,17 @@ module.exports = async (view_name='gramadoir_view') => {
         as: 'gramadoir',
       }},
       {$project: {
+        ownerId: 1,
         storyId: 1,
         gramadoir: {$arrayElemAt: ['$gramadoir', 0]}
       }},
       {$unset: 'gramadoirCacheId'},
       {$group: {
         _id: {
-          storyId: "$storyId"
+          storyId: "$storyId",
         },
         gramadoirHistory: {
-          $addToSet: "$gramadoir"
+          $addToSet: "$$ROOT"
         },
       }},
     ]

--- a/api/utils/gramadoirView.js
+++ b/api/utils/gramadoirView.js
@@ -1,0 +1,42 @@
+const mongoose = require('mongoose');
+const User = require('../models/user');
+
+module.exports = async (view_name='gramadoir_view') => {
+  await mongoose.connect('mongodb://localhost:27017/an-scealai');
+  const { db } = mongoose.connection;
+  await db.createCollection(view_name, {
+    viewOn: 'gramadoir.story.history',
+    pipeline: [
+      {$unwind: {
+        path: "$versions",
+        includeArrayIndex: "versionIdx",
+      }},
+      {$replaceRoot: {
+        newRoot: {
+          $mergeObjects: ["$$ROOT", "$versions"]
+        },
+      }},
+      {$unset: 'versions'},
+      {$lookup: {
+        from: 'gramadoir.cache',
+        localField: 'gramadoirCacheId',
+        foreignField: '_id',
+        as: 'gramadoir',
+      }},
+      {$project: {
+        storyId: 1,
+        gramadoir: {$arrayElemAt: ['$gramadoir', 0]}
+      }},
+      {$unset: 'gramadoirCacheId'},
+      {$group: {
+        _id: {
+          storyId: "$storyId"
+        },
+        gramadoirHistory: {
+          $addToSet: "$gramadoir"
+        },
+      }},
+    ]
+  });
+  return;
+};


### PR DESCRIPTION
Although the text and errors of the gramadoir response is stored in a seperate collection from the history/timestamps of when the gramadoir was run, we can create a view to collate the relevant documents together, and query it as if it were all in a single collection.

Spin up a mongod instance with some documents in `gramadoir.story.history` and `gramadoir.cache` and then run
`node api/mongo_scripts/gramadoirViewExample.js`