### PR TITLE
put translations of different keys together in source file

### DIFF
--- a/ngapp/src/abairconfig.json
+++ b/ngapp/src/abairconfig.json
@@ -1,3 +1,0 @@
-{
-    "baseurl" : "http://localhost:4000/"
-}

--- a/ngapp/src/abairconfig.prod.json
+++ b/ngapp/src/abairconfig.prod.json
@@ -1,3 +1,0 @@
-{
-    "baseurl" : "https://www.abair.ie/anscealaibackend/"
-}

--- a/ngapp/src/abairconfig.qa.json
+++ b/ngapp/src/abairconfig.qa.json
@@ -1,3 +1,0 @@
-{
-    "baseurl" : "https://www.abair.ie/qa/anscealaibackend/"
-}

--- a/ngapp/src/app/change_translation.ts
+++ b/ngapp/src/app/change_translation.ts
@@ -1,0 +1,14 @@
+import t from './translation';
+
+const en = t.languages[0];
+const ga = t.languages[1];
+
+const x = {};
+
+for(const k of Object.keys(en)) {
+  x[k] = {
+    ga: ga[k],
+    en: en[k],
+  }
+}
+console.dir(x);

--- a/ngapp/src/app/new_translation.ts
+++ b/ngapp/src/app/new_translation.ts
@@ -1,0 +1,1523 @@
+export default {
+  iso_code: { ga: 'ga', en: 'en' },
+  vowels_should_agree: {
+    ga: 'Ba cheart go mbeadh na gutaí seo ar aon dul de réir riail Leathan / Caol.',
+    en: 'These vowels should be in agreement according to the Leathan/Caol rule.'
+  },
+  name: { ga: 'Gaeilge', en: 'English' },
+  english: { ga: 'Béarla', en: 'English' },
+  irish: { ga: 'Gaeilge', en: 'Irish' },
+  quote: {
+    ga: 'Cinnlae Fhoghlaim na Gaeilge sa Ré Dhigiteach',
+    en: '"For the things we have to learn before we can do them, we learn by doing them."'
+  },
+  author: { ga: ' ', en: '- Aristotle' },
+  about: { ga: 'Cúlra', en: 'About' },
+  report_an_issue: { ga: 'Fadhb a Thuairisciú', en: 'Report An Issue' },
+  report_an_issue_prose: {
+    ga: 'Má thugann tú faoi deara go bhfuil fadhb ar bith le haon cheann de na seirbhísí atá ar shuíomh gréasáin An Scéalaí ba mhór againn dá gcuirfeá é sin in iúl dúinn agus réiteoimid í a luaithe agus is féidir. ‘Sé an seoladh teagmhála atá againn ná ',
+    en: 'If you have noticed any issues with any of the services provided on the An Scéalaí website we would be delighted to hear from you so that we can get it fixed as quickly as possible. You can reach the team at '
+  },
+  report_an_issue_ps: {
+    ga: 'Bímid i gcónaí sásta cloisteáil uaibh chomh maith faoi aon tairbhe ar leith a bhain sibh as an suíomh.',
+    en: "We are also always grateful to hear about any positive experiences you've had with the site."
+  },
+  the_team: { ga: 'An Fhoireann', en: 'The Team' },
+  technology: { ga: 'Teicneolaíocht', en: 'Technology' },
+  tech_in_scealai: { ga: 'Teic. in An Scéalaí', en: 'Tech. in An Scéalaí' },
+  other_CALL_projects: {
+    ga: 'Tionscadail eile FRT in ABAIR',
+    en: 'Other CALL projects in ABAIR'
+  },
+  irish_stories: { ga: 'Scéalta', en: 'Irish Stories' },
+  what_is_LARA: { ga: 'Cad é LARA?', en: 'What is LARA?' },
+  resources: { ga: 'Acmhainní', en: 'Resources' },
+  external_links: { ga: 'Nasc seachtrach', en: 'External links' },
+  language: { ga: 'Teanga', en: 'Language' },
+  other_language: { ga: 'English', en: 'Gaeilge' },
+  sign_in: { ga: 'Sínigh isteach', en: 'Sign in' },
+  i_am_a_teacher: { ga: 'Is múinteoir mé', en: 'I am a teacher' },
+  i_am_a_student: { ga: 'Is dalta mé', en: 'I am a student' },
+  already_have_account: { ga: 'Tá cuntas agam.', en: 'Already have an account?' },
+  username: { ga: 'Ainm úsáideora', en: 'Username' },
+  username_not_found: { ga: 'Níor thángthas ar an ainm seo', en: 'Username not found' },
+  username_taken_msg: {
+    ga: 'Ainm úsáideora tógtha, roghnaigh ceann eile le do thoil.',
+    en: 'Username taken, please choose another.'
+  },
+  username_changed_starting_from_scratch: {
+    ga: 'Athraíodh ainm úsáideora. Ag tosú ón tús.',
+    en: 'Username changed. Starting from scratch.'
+  },
+  username_and_password_required: {
+    ga: 'Ainm úsáideora agus pasfhocal de dhíth.',
+    en: 'Username and password required.'
+  },
+  user_not_verified_cannot_reset_password: {
+    ga: 'Níor fíoraíodh seoladh ríomhphost an úsáideora. Ní féidir pasfhocal a athshocrú.',
+    en: 'User email has not been verified. Cannot reset password.'
+  },
+  password: { ga: 'Pasfhocal', en: 'Password' },
+  reset_password: { ga: 'Pasfocal a athshocrú', en: 'Reset password' },
+  incorrect_password: { ga: 'Pasfhocal mícheart.', en: 'Incorrect password.' },
+  forgot_password: {
+    ga: 'An ndearna tú dearmad ar do phasfocal?',
+    en: 'Forgot your password?'
+  },
+  forgot_password_prose: {
+    ga: "Scríobh isteach d'ainm úsáideora. Má tá seoladh ríomhphoist fíoraithe ar fáil seolfaimid treoracha chugat chun do phasfhocal a athshocrú. Mura bhfuil do seoladh ríomhphoist fíoraithe cheanna féin ba cheart duit teagmháil a dhéanam linn go díreach. B'fhéidir go mbeimid in ann do phasfhocal a athshocrú de láimh.",
+    en: 'Provide your username and we will send a message to your verified email address with instructions to reset your password. If your email address has not already been verified you should contact us directly. We may be able to manually reset your password.'
+  },
+  enter_password: { ga: 'Scríobh isteach pasfhocal.', en: 'Enter password' },
+  my_stories: { ga: 'Mo Chuid Scéalta', en: 'My Stories' },
+  title: { ga: 'Teideal', en: 'Title' },
+  last_updated: { ga: 'An Leagan is Déanaí', en: 'Last Updated' },
+  options: { ga: 'Roghanna', en: 'Options' },
+  new_story: { ga: 'Cum Scéal', en: 'New Story' },
+  search_story_title_or_content: {
+    ga: 'Cuardaigh teideal nó ábhar scéil',
+    en: 'Search story title or content'
+  },
+  back: { ga: 'Siar', en: 'Back' },
+  dialect: { ga: 'Canúint', en: 'Dialect' },
+  munster: { ga: 'Mumha', en: 'Munster' },
+  connacht: { ga: 'Connachta', en: 'Connacht' },
+  ulster: { ga: 'Ulaidh', en: 'Ulster' },
+  create: { ga: 'Cruthaigh', en: 'Create' },
+  contents: { ga: 'Clár Scéalta', en: 'Contents' },
+  save: { ga: 'Sábháil', en: 'Save' },
+  saved: { ga: 'I dtaisce', en: 'Saved' },
+  saving: { ga: 'Ag sábháil', en: 'Saving' },
+  feedback: { ga: 'Aiseolas', en: 'Feedback' },
+  new_feedback: { ga: 'Aiseolas Nua', en: 'New Feedback' },
+  audio_check: { ga: 'Seiceáil ó Chluas', en: 'Audio Check' },
+  grammar_check: { ga: 'Seiceáil Gramadaí', en: 'Grammar Check' },
+  show_grammar_suggestions: { ga: 'Taispeáin moltaí gramadaí', en: 'Show grammar suggestions' },
+  hide_grammar_suggestions: {
+    ga: 'Ná taispeáin moltaí gramadaí',
+    en: 'Hide grammar suggestions'
+  },
+  grammar_checker_settings: {
+    ga: 'Socraithe don seiceálaí gramadaí',
+    en: 'Grammar checker settings'
+  },
+  hover_over_a_highlighted_word_for_a_grammar_suggestion: {
+    ga: 'Cuir do luch ar fhocal/frása aibhsithe le haghaidh moltaí gramadaí',
+    en: 'Hover over a highlighted word/phrase for a grammar suggestion'
+  },
+  listen_and_correct: {
+    ga: 'Éist agus Ceartaigh más Gá',
+    en: 'Listen and Correct if necessary'
+  },
+  listen_back_to_your_story: { ga: 'Éist le do scéal', en: 'Listen to your story' },
+  correcting_grammar: { ga: 'An Ghramadach á Seiceáil', en: 'Correcting Grammar' },
+  grammar_checker: { ga: 'Seiceálaí Gramadaí', en: 'Grammar Checker' },
+  uncheck_all: { ga: 'Bain na ticeanna uilig', en: 'Uncheck all' },
+  check_all: { ga: 'Cuir tic i ngach bosca', en: 'Check all' },
+  gramadoir: { ga: 'An Gramadóir', en: 'An Gramadóir' },
+  broad_slender: { ga: 'Seiceáil ar Leathan/Caol', en: 'Broad/Slender Checker' },
+  profile: { ga: 'Mo chuid sonraí', en: 'My Profile' },
+  classroom_code: { ga: 'Cód ranga', en: 'Classroom code' },
+  enter_code: { ga: 'Cód anseo', en: 'Enter code' },
+  sign_out: { ga: 'Sínigh amach', en: 'Sign out' },
+  word_count: { ga: 'Líon Focal', en: 'Word Count' },
+  change_username: { ga: 'Athraigh ainm úsáideora', en: 'Change Username' },
+  you_will_have_to_login: {
+    ga: "Logáil isteach arís le d'ainm úsáideora nua",
+    en: 'You will have to login again with your new username'
+  },
+  current_username: { ga: 'Ainm úsáideora reatha', en: 'Current username' },
+  new_username: { ga: 'Ainm úsáideora nua', en: 'New username' },
+  enter_username: { ga: "Scríobh isteach d'ainm úsáideora", en: 'Enter username' },
+  change_password: { ga: 'Athraigh do phasfhocal', en: 'Change password' },
+  you_will_have_to_login_password: {
+    ga: 'Beidh ort logáil isteach arís le do phasfhocal nua',
+    en: 'You will have to login again with your new password'
+  },
+  new_password: { ga: 'Pasfhocal nua', en: 'New password' },
+  please_input_a_new_password_confirm: {
+    ga: 'Cuir isteach an pasfhocal nua agus deimhnigh',
+    en: 'Please input a new password and confirm'
+  },
+  please_input_a_new_username: {
+    ga: 'Cuir isteach ainm úsáideora nua, le do thoil',
+    en: 'Please input a new username'
+  },
+  leave: { ga: 'Fág', en: 'leave' },
+  classroom: { ga: 'Rang', en: 'Classroom' },
+  join_classroom: { ga: 'Isteach sa rang', en: 'Join classroom' },
+  my_info: { ga: 'Eolas fúm', en: 'My Information' },
+  register: { ga: 'Cláraigh', en: 'Register' },
+  username_in_use: { ga: '*An t-ainm tógtha cheana', en: '*Username already in use' },
+  create_password: { ga: 'Cruthaigh pasfhocal', en: 'Create Password' },
+  confirm_password: { ga: 'Deimhnigh do phasfhocal', en: 'Confirm Password' },
+  personal_info: { ga: 'Eolas pearsanta', en: 'Personal Information' },
+  profile_instructions: {
+    ga: 'Táimid ag iarraidh ort an ceistneoir seo a líonadh ar mhaithe le taighde a cheadóidh comparáidí idirnáisiúnta le teangacha éagsúla.',
+    en: 'We are asking you to complete the following questionnaire for research purposes, in order to facilitate international comparisons between different language acquisition patterns.'
+  },
+  verify_email_address: { ga: 'Seoladh ríomhphoist a fhíorú', en: 'Verify email address' },
+  verify_email_prose: {
+    ga: 'Tá ríomhphost seolta againn chugat. Cliceáil ar an nasc sa ríomhphost chun do sheoladh ríomhphoist a fhíorú.',
+    en: "We have sent you an email. Click the link in the email to verify your email address. Once you've done that you will be able to log in again."
+  },
+  error_sending_email: {
+    ga: 'Erráid éigin ag seoladh ríomhphost.',
+    en: 'An error occurred while trying to send a verification email.'
+  },
+  email_not_verified: {
+    ga: 'Níor fíoraíodh do sheoladh ríomhphoist go fóill. Caithfidh tú do sheoladh ríomhphoist a fhíorú chun síniú isteach.',
+    en: 'Your email address has not yet been verified. You must verify your email address to sign in.'
+  },
+  gender: { ga: 'Gnéas', en: 'Gender' },
+  gender_list: {
+    ga: [ '', 'Fireann', 'Baineann', 'Uilíoch', "B'fhearr liom gan a rá" ],
+    en: [ '', 'Male', 'Female', 'Non-Binary', 'Prefer not to say' ]
+  },
+  male: { ga: 'Fireann', en: 'Male' },
+  female: { ga: 'Baineann', en: 'Female' },
+  non_binary: { ga: 'Uilíoch', en: 'Non-Binary' },
+  prefer_not_say: { ga: "B'fhearr liom gan a rá", en: 'Prefer not to say' },
+  age: { ga: 'Aois', en: 'Age' },
+  county: { ga: 'Contae', en: 'County' },
+  not_from_ireland: {
+    ga: 'Ní as Poblacht na hÉireann ná as Tuaisceart Éireann mé',
+    en: "I'm not from the Republic of Ireland or Northern Ireland"
+  },
+  country: { ga: 'Tír', en: 'Country' },
+  current_studies: { ga: 'Leibhéal scolaíochta', en: 'Current studies' },
+  type_of_school: {
+    ga: 'Cén cineál scoile ar fhreastail / a bhfuil tú ag freastal uirthi?',
+    en: 'What type of school did you go to / are you going to?'
+  },
+  schools_list: {
+    ga: [
+      '',
+      'Scoil Bhéarla',
+      'Gaelscoil',
+      'Scoil Gaeltachta',
+      'Ní fhreastail mé ar scoil in Éirinn'
+    ],
+    en: [
+      '',
+      'English school',
+      'Gaelscoil',
+      'Gaeltacht school',
+      'I did not attend school in Ireland'
+    ]
+  },
+  english_school: { ga: 'Scoil Bhéarla', en: 'English school' },
+  gaelscoil: { ga: 'Gaelscoil', en: 'Gaelscoil' },
+  gaeltacht_school: { ga: 'Scoil Gaeltachta', en: 'Gaeltacht school' },
+  school_not_in_ireland: {
+    ga: 'Ní fhreastail mé ar scoil in Éirinn',
+    en: 'I did not attend school in Ireland'
+  },
+  student_school_level_list: {
+    ga: [
+      '',
+      'Is dalta bunscoile mé',
+      'Is dalta iar-bhunscoile mé',
+      'Is mac léinn tríú leibhéal mé in Éirinn',
+      'Táim ag déanamh staidéar ar an nGaeile i Stáit Aontaithe Mheirceá',
+      'Táim ag déanamh staidéir ar an nGaeilge taobh amuigh d’Éirinn agus de Stáit Aontaithe Mheirceá',
+      'Is mac léinn iarchéime mé'
+    ],
+    en: [
+      '',
+      'I am a primary school pupil',
+      'I am a secondary school pupil',
+      'I am a 3rd level student in Ireland',
+      'I am studying Irish in the USA',
+      'I am studying Irish outside of Ireland or USA',
+      'I am a postgraduate student'
+    ]
+  },
+  primary_years_list: {
+    ga: [
+      '',
+      'Táim i Rang a haon',
+      'Táim i Rang a dó',
+      'Táim i Rang a trí',
+      'Táim i Rang a ceathair',
+      'Táim i Rang a cúig',
+      'Táim i Rang a sé'
+    ],
+    en: [
+      '',
+      'I am in 1st class',
+      'I am in 2nd class',
+      'I am in 3rd class',
+      'I am in 4th class',
+      'I am in 5th class',
+      'I am in 6th class'
+    ]
+  },
+  secondary_years_list: {
+    ga: [
+      '',
+      'Táim i mBliain a 1 ',
+      'Táim i mBliain a 2',
+      'Táim i mBliain a 3r',
+      'Táim i mBliain a 4',
+      'Táim i mBliain a 5',
+      'Táim i mBliain a 6'
+    ],
+    en: [
+      '',
+      'I am in 1st year',
+      'I am in 2nd year',
+      'I am in 3rd year',
+      'I am in 4th year',
+      'I am in 5th year',
+      'I am in 6th year'
+    ]
+  },
+  what_are_you_studying: {
+    ga: 'Cad é do phríomh-ábhar staidéir?',
+    en: 'What are you studying?'
+  },
+  third_level_options_list: {
+    ga: [
+      '',
+      'Tá céim sa Ghaeilge ar siúl agam',
+      'Táim ag gabháil de chéim san Oideachas agus an Ghaeilge mar mhór-ábhar agam',
+      'Táim ag gabháil de chéim san Oideachas agus an Ghaeilge mar mhion-ábhar agam',
+      'Tá ag gabháil de chéim san Oideachas mar iar-chéimí',
+      'Eile'
+    ],
+    en: [
+      '',
+      'I am studying Irish',
+      'I am studying Education Primary (with Irish as a major component)',
+      'I am studying Education Primary (with Irish as a minor component)',
+      'I am studying Education as a Postgraduate student',
+      'Other'
+    ]
+  },
+  third_level_years_list: {
+    ga: [
+      '',
+      'Táim sa chéad bhliain',
+      'Táim sa dara bliain',
+      'Táim sa tríú bliain de chúrsa ceithre bliana',
+      'Táim sa bhliain dheireanach den chéim'
+    ],
+    en: [
+      '',
+      'I am in 1st year',
+      'I am in 2nd year',
+      'I am in 3rd year of a 4 year course',
+      'I am in final year'
+    ]
+  },
+  third_level_years_list_short: {
+    ga: [
+      '',
+      'Táim sa chéad bhliain',
+      'Táim sa dara bliain',
+      'Táim sa tríú bliain',
+      'Táim sa bhliain dheireanach den chéim'
+    ],
+    en: [
+      '',
+      'I am in 1st year',
+      'I am in 2nd year',
+      'I am in 3rd year',
+      'I am in final year'
+    ]
+  },
+  usa_options_list: {
+    ga: [
+      '',
+      'Déanaim rang Gaeilge san Ollscoil',
+      'Níl mé cláraithe do ranganna Gaeilge in aon Ollscoil'
+    ],
+    en: [
+      '',
+      'I am taking an Irish class at a University',
+      'I am not enrolled in an Irish language class at a University'
+    ]
+  },
+  please_specify: { ga: 'Luaigh', en: 'Please specify' },
+  specify_where: { ga: 'Luaigh an áit', en: 'Specify where' },
+  attending_gaeltacht_immersion_course: {
+    ga: 'Táim ag freastal ar chúrsa Gaeltachta faoi láthair',
+    en: 'I am currently attending a Gaeltacht immersion course'
+  },
+  immersion_list: { ga: [ '', 'Tá', 'Níl' ], en: [ '', 'Yes', 'No' ] },
+  studies: { ga: 'Ábhar staidéir', en: 'Studies' },
+  primary: { ga: 'Bunscoil', en: 'Primary' },
+  secondary: { ga: 'Iar-bhunscoil', en: 'Secondary' },
+  third_level: { ga: 'Cúrsa 3ú leibhéal', en: '3rd level' },
+  gaeltacht_immersion_course: { ga: 'Cúrsa Gaeltachta', en: 'Gaeltacht immersion course' },
+  school_type_where_you_teach: {
+    ga: 'An áit ina bhfuil tú ag múineadh',
+    en: 'School type where you teach'
+  },
+  yes: { ga: 'Sea', en: 'Yes' },
+  no: { ga: 'Ní hea', en: 'No' },
+  bilingual_native: { ga: 'Dátheangach (cainteoir dúchais)', en: 'Bilingual (native)' },
+  bilingual_other: { ga: 'Dátheangach (eile)', en: 'Bilingual (other)' },
+  native_speaker_status_list: {
+    ga: [
+      '',
+      'Sea',
+      'Ní hea',
+      'Dátheangach (cainteoir dúchais)',
+      'Dátheangach (eile)'
+    ],
+    en: [ '', 'Yes', 'No', 'Bilingual (native)', 'Bilingual (other)' ]
+  },
+  dialect_preference_list: {
+    ga: [
+      '',
+      'Gaeilge Uladh',
+      'Gaeilge Chonnacht',
+      'Gaolainn na Mumhan',
+      'Eile'
+    ],
+    en: [
+      '',
+      'Gaeilge Uladh',
+      'Gaeilge Chonnacht',
+      'Gaolainn na Mumhan',
+      'Other'
+    ]
+  },
+  gaeilge_uladh: { ga: 'Gaeilge Uladh', en: 'Gaeilge Uladh' },
+  gaeilge_chonnacht: { ga: 'Gaeilge Chonnacht', en: 'Gaeilge Chonnacht' },
+  gaolainn_na_mumhan: { ga: 'Gaolainn na Mumhan', en: 'Gaolainn na Mumhan' },
+  other: { ga: 'Eile', en: 'Other' },
+  spoken_comprehension_level_list: {
+    ga: [
+      '',
+      'Cúpla focal má labhraítear go mal',
+      'Cúpla abairt simplí má labhraítear go mall',
+      'Cuid den comhrá',
+      'An chuid is mó den chomhrá má labhraítear go soléir',
+      'Beagnach gach rud ar ghnáthluas cainte'
+    ],
+    en: [
+      '',
+      'A few words when spoken slowly',
+      'A few simple phrases when spoken slowly',
+      'Parts of the conversation',
+      'Most of the conversation when spoken clearly',
+      'Almost everything when spoken at a normal pace'
+    ]
+  },
+  comprehension_level_1: {
+    ga: 'Cúpla focal má labhraítear go mall',
+    en: 'A few words when spoken slowly'
+  },
+  comprehension_level_2: {
+    ga: 'Cúpla abairt simplí má labhraítear go mall',
+    en: 'A few simple phrases when spoken slowly'
+  },
+  comprehension_level_3: { ga: 'Cuid den comhrá', en: 'Parts of the conversation' },
+  comprehension_level_4: {
+    ga: 'An chuid is mó den chomhrá má labhraítear go soléir',
+    en: 'Most of the conversation when spoken clearly'
+  },
+  comprehension_level_5: {
+    ga: 'Beagnach gach rud ar ghnáthluas cainte',
+    en: 'Almost everything when spoken at a normal pace'
+  },
+  unknown: { ga: 'Anaithnid', en: 'unknown' },
+  how_often_options_list: {
+    ga: [
+      '',
+      'Gach lá',
+      'Gach seachtain ach ní gach lá',
+      'Cúpla uair sa mhí',
+      'Go fíor-annamh'
+    ],
+    en: [
+      '',
+      'Every day',
+      'Every week but not every day',
+      'A few times a month',
+      'Hardly ever'
+    ]
+  },
+  every_day: { ga: 'Gach lá', en: 'Every day' },
+  every_week: {
+    ga: 'Gach seachtain ach ní gach lá',
+    en: 'Every week but not every day'
+  },
+  few_times_a_month: { ga: 'Cúpla uair sa mhí', en: 'A few times a month' },
+  hardly_ever: { ga: 'Go fíor-annamh', en: 'Hardly ever' },
+  who_speak_with_list: {
+    ga: [
+      '',
+      'Foghlaimeoirí agus cainteoirí dúchais',
+      'Cainteoirí dúchais',
+      'Foghlaimeoirí'
+    ],
+    en: [
+      '',
+      'Learners and native speakers',
+      'Native speakers',
+      'Learners'
+    ]
+  },
+  learners_and_natives: {
+    ga: 'Foghlaimeoirí agus cainteoirí dúchais',
+    en: 'Learners and native speakers'
+  },
+  natives: { ga: 'Cainteoirí dúchais', en: 'Native speakers' },
+  learners: { ga: 'Foghlaimeoirí', en: 'Learners' },
+  list_languages_spoken: {
+    ga: 'Déan liosta de na teangacha a úsáideann do theaghlach/gnáth-ráta úsáide atá ag gach ceann',
+    en: 'List languages spoken at home/average use of each'
+  },
+  father_native_tongue: { ga: 'Teanga dhúchas d’athar', en: "Father's native tongue" },
+  mother_native_tongue: { ga: 'Teanga dhúchas do mháthar', en: "Mother's native tongue" },
+  years_of_irish_school: {
+    ga: 'An mó bliain atá caite agat leis an nGaeilge ar scoil/Ollscoil?',
+    en: 'How many years of Irish at school/university?'
+  },
+  list_other_foreign_languages: {
+    ga: 'Déan liosta de theangacha eile atá agat in ord do líofachta (ag tosú leis an gceann is líofa agat).',
+    en: 'List other foreign languages you speak in decreasing order of proficiency'
+  },
+  synth_opinion_list: {
+    ga: [
+      '',
+      'Ní maith liom iad',
+      'Tá siad ceart go leor, ach is fearr liom guth daonna',
+      'Is cuma liom an ríomhaire nó duine a bhíonn ag caint',
+      'Uaireanta bíonn guth sintéiseach feiliúnach',
+      'Uaireanta bíonn guth sintéiseach níos fearr'
+    ],
+    en: [
+      '',
+      "I don't like them",
+      "They're okay, but I prefer a human voice",
+      "I don't care if it is a computer or person",
+      'Sometimes synthetic voices just fit',
+      'Sometimes synthetic voices are better suited'
+    ]
+  },
+  synth_opinion_1: { ga: 'Ní maith liom iad', en: "I don't like them" },
+  synth_opinion_2: {
+    ga: 'Tá siad ceart go leor, ach is fearr liom guth daonna',
+    en: "They're okay, but I prefer a human voice"
+  },
+  synth_opinion_3: {
+    ga: 'Is cuma liom an ríomhaire nó duine a bhíonn ag caint',
+    en: "I don't care if it is a computer or person"
+  },
+  synth_opinion_4: {
+    ga: 'Uaireanta bíonn guth sintéiseach feiliúnach',
+    en: 'Sometimes synthetic voices just fit'
+  },
+  synth_opinion_5: {
+    ga: 'Uaireanta bíonn guth sintéiseach níos fearr',
+    en: 'Sometimes synthetic voices are better suited'
+  },
+  social_media: { ga: 'Meáin shoisialta', en: 'Social Media' },
+  native_speaker: { ga: 'Cainteoir dúchais', en: 'Irish Native Speaker' },
+  how_well_understand_spoken: {
+    ga: 'Cén tuiscint atá agat ar Ghaeilge labhartha?',
+    en: 'How well do you understand spoken Irish?'
+  },
+  whats_cefr_level: { ga: 'Cén léibhéal CEFR atá agat?', en: "What's your CEFR level?" },
+  how_often_speak: {
+    ga: 'Cé chomh minic a labhraíonn tú Gaeilge?',
+    en: 'How often do you speak Irish?'
+  },
+  who_speak_with: {
+    ga: 'Cé a labhraíonn tú Gaeilge leis?',
+    en: 'With whom do you normally speak Irish?'
+  },
+  watch_irish_media: {
+    ga: 'An mbreathnaíonn / éisteann tú le meáin as Gaeilge?',
+    en: 'Do you watch or listen to Irish language media?'
+  },
+  read_irish: { ga: 'An léann tú as Gaeilge?', en: 'Do you read in Irish?' },
+  write_irish: { ga: 'An scríobhann tú as Gaeilge?', en: 'Do you write in Irish?' },
+  synthetic_voices_info: {
+    ga: 'Tá guthanna sintéiseacha an-choitianta sa lá atá inniú ann. Cloistear san ardaitheoir, ag an aerfort nó in óstáin iad, agus baineann comhlachtaí móra úsáid astu chun glaonna gutháin a fhreagairt go minic.',
+    en: 'Synthetic voices are very common nowadays. You can hear them in elevators, at the airport, in hotels, and big companies often use them to answers phone calls.'
+  },
+  synthetic_voices_opinion: {
+    ga: 'Céard í do thuairim faoi ghuthanna sintéiseacha?',
+    en: "What's your opinion of synthetic voices?"
+  },
+  newspapers: { ga: 'Páipéir nuachta', en: 'Newspapers' },
+  books: { ga: 'Leabhair', en: 'Books' },
+  verification: { ga: 'Fíorú', en: 'Verification' },
+  email: { ga: 'Ríomhphost', en: 'Email' },
+  email_address: { ga: 'Seoladh ríomhphoist', en: 'Email address' },
+  email_sms: { ga: 'Ríomhphost, SMS', en: 'Email, SMS' },
+  email_format_error: {
+    ga: 'Níl an seoladh ríomhphoist i bhformáid cheart. Tabhair seoladh ríomhphoist den fhoirm <ainm>@<seirbhís>.<fearann> le do thoil.',
+    en: 'The email address is not of a correct format. Please provide an email address of the form <name>@<service>.<domain>.'
+  },
+  email_sent: { ga: 'Tá ríomhphost seolta.', en: 'An email has been sent.' },
+  blogs: { ga: 'Blag(anna)', en: 'Blog(s)' },
+  teaching_material: { ga: 'Ábhar teagaisc', en: 'Teaching Material' },
+  articles: { ga: 'Altanna', en: 'Articles' },
+  short_stories: { ga: 'Gearrscéalta', en: 'Short Stories' },
+  poetry: { ga: 'Filíocht', en: 'Poetry' },
+  synthetic_voices: { ga: 'Guthanna sintéiseacha', en: 'Synthetic Voices' },
+  language_competence: { ga: 'Cumas teanga', en: 'Language Competence' },
+  exposure_to_irish: { ga: 'Cleachtadh ar an nGaeilge', en: 'Exposure to Irish' },
+  which_dialect: {
+    ga: 'Cén chanúint Ghaeilge is éasca duit?',
+    en: 'Which dialect of Irish are you most comfortable with?'
+  },
+  how_often: { ga: 'Cé chomh minic?', en: 'How often?' },
+  save_details: { ga: 'Sábháil na sonraí', en: 'Save details' },
+  teacher_registration: { ga: 'Clárú múinteora', en: 'Teacher Registration' },
+  activation_code: { ga: 'Cód gníomhaithe', en: 'Activation code' },
+  save_changes_made_to: {
+    ga: 'Sábháil na hathruithe a rinneadh ar ',
+    en: 'Save changes made to'
+  },
+  cancel: { ga: 'Cealaigh', en: 'Cancel' },
+  choose_an_error: {
+    ga: 'Roghnaigh earráid len í a fhiosrú',
+    en: 'Choose an error to see details'
+  },
+  edit: { ga: 'Athraigh teideal/canúint', en: 'Edit Title/Dialect' },
+  no_feedback_provided: {
+    ga: 'Níl aon aiseolas tugtha faoin scéal seo',
+    en: 'No feedback has been provided for this story'
+  },
+  username_password_and_email_required: {
+    ga: 'Gá le ainm úsáideora, pasfhocal, agus seoladh ríomhphost.',
+    en: 'Username, password, and email required.'
+  },
+  title_required: { ga: 'Gá le teideal', en: 'Title is required' },
+  story_details: { ga: 'Sonraí an scéil', en: 'Story Details' },
+  synthesising: { ga: 'Ag déanamh na sintéise', en: 'Synthesising' },
+  story: { ga: 'Scéal', en: 'Story' },
+  no_feedback_given: { ga: 'Gan aiseolas (tugtha)', en: 'No feedback given' },
+  filter_by: { ga: 'Scag trí', en: 'Filter by' },
+  agree_to_terms: {
+    ga: 'Ar chlárú dom glacaim leis na coinníollacha úsáide',
+    en: 'By registering I agree to the terms of use'
+  },
+  terms_of_use: {
+    ga: "Nuair a chláirím tuigim go n-úsáidfear mo chuid sonraí ar mhaithe le taighde teangeolaíochta agus ar mhaithe le teicneolaíocht na hurlabhra agus teanga a fhorbairt don Ghaeilge. Coimeádfar na sonraí ar fad ar fhreastalaí atá slán faoi chosaint pasfhocail sa tSaotharlann Foghraíochta & Urlabhra, Scoil na nEolaíochtaí Teangeolaíochta, Urlabhra agus Cumarsáide, Coláiste na Tríonóide agus ní roinnfear iad le héinne lasmuigh d'fhoireann lárnach na taighe. Tuilleadh eolais ar fáil ón Ollamh Neasa Ní Chiaráin - neasa.nichiarain@tcd.ie",
+    en: 'By registering I understand that my details will be used for linguistic research and for Irish Speech and Language Technology development. Data will be stored on a password protected secure server at the Phonetics and Speech Lab, School of Linguistic, Speech and Communication Sciences, Trinity College, Dublin and not shared with anyone outside the core research team. For more information contact Prof. Neasa Ní Chiaráin - neasa.nichiarain@tcd.ie'
+  },
+  about_an_scealai: { ga: 'Faoi An Scéalaí', en: 'About An Scéalaí' },
+  about_quote: {
+    ga: 'Technology is the campfire around which we tell our stories',
+    en: 'Technology is the campfire around which we tell our stories'
+  },
+  about_quote_author: { ga: 'Laurie Anderson', en: 'Laurie Anderson' },
+  about_content_text_academic: {
+    ga: '    Tionscadal nua is ea An Scéalaí atá á fhorbairt faoi láthair. Ardán Foghlaim Ríomhchuidithe Teanga-cliste atá ann a tharraingíonn na forbairtí is déanaí i dteicneolaíocht na hurlabhra agus na teanga don Ghaeilge le chéile ar mhaithe le teagasc/foghlaim na Gaeilge. Is cur chuige iomlánaíoch atá i gceist, a dhíríonn ar an scríobh, éisteacht, léamh agus caint ag an am céanna, le béim ar leith ar na nascanna idir an focal scíofa agus an fuaimniú. Tá sé mar aidhm againn ardán a chruthú d’fhoghlaimeoirí atá idirghníomhach agus pearsantaithe chun sealbhú an dara teanga a chothú. Is féidir le daoine An Scéalaí a úsáid iad féin agus leas a bhaint as an aiseolas a ghineann an córas go huathoibríoch agus/nó is féidir an t-ardán a úsáid mar acmhainn bhreise le cur leis an méid atá ar siúl sa seomra ranga, agus aiseolas an mhúinteora a fháil chomh maith. Seo a leanas foilseachán a thugann an cúlra, na haidhmeanna agus an fhorbairt atá déanta go dtí seo.',
+    en: 'An Scéalaí is currently under development. It is an intelligent Computer-Assisted Language Learning (iCALL) platform for Irish which exploits the latest developments in Irish speech and language technology as its key feature. It promotes a holistic approach to language learning, simultaneously training the four skills of writing, listening, reading and speaking, focusing particularly on reinforcing the linkages between the spoken and written word. The goal is to offer the learner an interactive, personalised experience to foster their second language learning. It can be used as a standalone platform, incorporating automatic feedback and/or as a complement to classroom learning, incorporating teacher feedback. The following paper summarises the approach, rationale and development to date.'
+  },
+  technology_in_an_scealai: {
+    ga: 'Teicneolaíocht in úsáid in <i>An Scéalaí</i>',
+    en: 'Technology in <i>An Scéalaí</i>'
+  },
+  abair_technology_title: {
+    ga: 'ABAIR: an focal scríofa go caint bheo',
+    en: 'The ABAIR initiative: speech synthesis for Irish'
+  },
+  gramadoir_technology_title: {
+    ga: 'An Gramadóir: seiceálaí gramadaí forbartha ag Kevin Scannell',
+    en: 'An Gramadóir: grammar checker for Irish developed by Kevin Scannell'
+  },
+  NLP_title: {
+    ga: 'Uirlisí Próiseála Téacs don Ghaeilge',
+    en: 'Natural Language Processing (NLP) Tools for Irish'
+  },
+  LARA_technology_title: {
+    ga: 'LARA – tionscadal CALLector ',
+    en: 'LARA - CALLector project'
+  },
+  add_new_classroom: { ga: 'Cruthaigh seomra ranga nua', en: 'Add new Classroom' },
+  enter_title: { ga: 'Cuir teideal isteach', en: 'Enter title' },
+  classrooms: { ga: 'Seomraí ranga', en: 'Classrooms' },
+  no_students: { ga: 'Líon na ndaltaí', en: 'No. Students' },
+  edit_classroom_title: { ga: 'Leasaigh ainm an tseomra ranga', en: 'Edit classroom title' },
+  edit_title_or_dialect: { ga: 'Athraigh teideal/canúint', en: 'Edit title/dialect' },
+  done: { ga: 'Críochnaithe', en: 'Done' },
+  sure_you_want_to_delete_code: {
+    ga: 'Cinnte go bhfuil tú ag iarraidh an cód seo a ghlanadh?',
+    en: 'Are you sure you want to delete this code?'
+  },
+  delete: { ga: 'Scrios', en: 'Delete' },
+  share_code: { ga: 'Roinn an cód', en: 'Share code' },
+  student_username: { ga: 'Ainm úsáideora an dalta', en: 'Student username' },
+  stories: { ga: 'Scéalta', en: 'stories' },
+  record_audio_message: {
+    ga: 'Déan taifead ar do theachtaireacht',
+    en: 'Record audio message'
+  },
+  record_audio: { ga: 'Déan taifead fuaime', en: 'Record audio' },
+  stop_recording: { ga: 'Stop an taifead', en: 'Stop recording' },
+  would_you_like_to_listen_back: {
+    ga: 'Ar mhaith leat éisteacht arís?',
+    en: 'Would you like to listen back to that?'
+  },
+  send: { ga: 'Seol ar aghaidh', en: 'Send' },
+  text: { ga: 'Téacs', en: 'Text' },
+  information: { ga: 'Eolas', en: 'Information' },
+  creation_date: { ga: 'Sonraí cruthaithe', en: 'Creation date' },
+  story_author: { ga: 'Údar an scéil', en: 'Author' },
+  seen_by: { ga: 'Feicthe ag', en: 'Seen by' },
+  not_seen_by: { ga: 'Níl sé feicthe ag', en: 'Not seen by' },
+  sent: { ga: 'Curtha ar aghaidh', en: 'Sent' },
+  audio_message: { ga: 'Clos-scéal', en: 'Audio message' },
+  leave_feedback_for: { ga: 'Fág aiseolas do', en: 'Leave some feedback for' },
+  type_of_school_teacher: { ga: 'Saghas scoile?', en: 'At what type of school do you teach?' },
+  school_name: { ga: 'Ainm na scoile', en: 'Name of the school where you teach' },
+  school_not_in_ireland_teacher: {
+    ga: 'Scoil thar sáile',
+    en: 'I do not teach at a school in Ireland'
+  },
+  passwords_must_match: {
+    ga: 'Ní mór do na pasfhocail freagairt dá chéile!',
+    en: 'Passwords must match!'
+  },
+  passwords_5_char_long: {
+    ga: '5 carachtar sa phasfhocal ar a laghad!',
+    en: 'Passwords must be at least 5 characters long!'
+  },
+  username_no_special_chars: {
+    ga: 'Ainm an úsáideora gan carachtair speisialta!',
+    en: 'Username may not contain special characters!'
+  },
+  click_new_story: {
+    ga: "Cliceáil 'Scéal Nua' thíos le do chéad scéal a scríobh!",
+    en: "Click 'New Story' below to create your first story!"
+  },
+  my_classrooms: { ga: 'Mo Sheomraí Ranga', en: 'My Classrooms' },
+  teacher_account_code: { ga: 'Cód chuntas an mhúinteora', en: 'Teacher account code' },
+  generate: { ga: 'Gin', en: 'Generate' },
+  copied: { ga: 'Cóipeáilte', en: 'Copied' },
+  active_account_codes: { ga: 'Cód Cuntais Reatha', en: 'Active Account Codes' },
+  search_user: { ga: 'Lorg Úsáideoir', en: 'Search User' },
+  admin_dashboard: { ga: 'Deais an Riarthóra', en: 'Admin Dashboard' },
+  teachers: { ga: 'Múinteoirí', en: 'Teachers' },
+  students: { ga: 'Daltaí', en: 'Students' },
+  admins: { ga: 'Riarthóirí', en: 'Admins' },
+  find_user: { ga: 'Aimsigh úsáideoir', en: 'Find User' },
+  all_users: { ga: 'Gach úsáideoir', en: 'All Users' },
+  results: { ga: 'Torthaí', en: 'Results' },
+  synthesis_breakdown: {
+    ga: 'Briseadh síos ar cheartúcháin a rinneadh ar an tsintéis',
+    en: 'Synthesis Error Correction Breakdown'
+  },
+  compiling_data: { ga: 'Sonraí á gcur le chéile', en: 'Compiling data' },
+  net_errors_corrected: { ga: 'Líon earráidí a ceartaíodhd', en: 'Net errors corrected' },
+  author_admin: { ga: 'Údar', en: 'Author' },
+  history_of_title: { ga: 'Stair an teidil', en: 'History of title' },
+  history_of_story: { ga: 'Stair an scéil', en: 'History of story' },
+  teacher_accounts: { ga: 'Cuntais na Múinteoirí', en: 'Teacher Accounts' },
+  profile_summary: { ga: 'Achoimre ar phróifíl do', en: 'Profile Summary for' },
+  role: { ga: 'Ról', en: 'Role' },
+  ISODate: { ga: 'Dáta ISO', en: 'ISODate' },
+  story_id: { ga: 'Comhartha aitheantais an scéil', en: 'Story id' },
+  story_text: { ga: 'Téacs an scéil', en: 'Story text' },
+  story_history: { ga: 'Súil Siar', en: 'Story History' },
+  scealai_feature_statistics: {
+    ga: 'Staitisticí Feidhmiúla an Scéalaí',
+    en: 'SScéalaí Features Statistics'
+  },
+  date_range: { ga: 'Raon Sonraíochta', en: 'Date Range' },
+  previous_data: { ga: 'Sonraí roimhe seo', en: 'Previous Data' },
+  enter_date_range: { ga: 'Cuir raon sonraíochta isteach', en: 'Enter a date range' },
+  invalid_start_date: { ga: 'Dáta tosaithe neamhbhailí', en: 'Invalid start date' },
+  invalid_end_date: { ga: 'Dáta deiridh neamhbhailí', en: 'Invalid end date' },
+  no_date_range_entered: {
+    ga: 'Ní haisghabhann aon raon sonraíochta san ionchur an tsonraíocht iomlán ón mbunachar',
+    en: 'No date range entered retrieves all data from the DB'
+  },
+  get_data: { ga: 'Faigh sonraí', en: 'Get Data' },
+  add_data_log: { ga: 'Cuir log sonraíochta leis seo', en: 'Add Data Log' },
+  profile_stats: { ga: 'Staitisticí faoi na próifílí', en: 'Profile Stats' },
+  feature_stats: { ga: 'Gné-staitisticí', en: 'Feature Stats' },
+  profiles_found: { ga: 'Próifílí a fuarthas', en: 'Profiles Found' },
+  gender_of_users: { ga: 'Gender of users', en: 'Gender of users' },
+  age_of_users: { ga: 'Aois na n-úsáideoirí', en: 'Age of users' },
+  countries_of_users: { ga: 'Tíortha na n-úsáideoirí', en: 'Countries of users' },
+  users_not_from_ireland: {
+    ga: 'Líon iomlán na n-úsáideoirí nach as Éirinn iad:',
+    en: 'Total users not from Ireland:'
+  },
+  county_of_users: {
+    ga: 'Contaetha na n-úsáideoirí as Éirinn',
+    en: 'County of users from Ireland'
+  },
+  student_school_level: { ga: 'Leibhéal Scoile na Macléann', en: 'Student School Level' },
+  which_level_type_of_schooling: {
+    ga: 'Leibhéal/Cineál scoile ina bhfuil úsáideoirí',
+    en: 'Which level/type of schooling users are in'
+  },
+  primary_year: { ga: 'An bhliain sa bhunscoil', en: 'Primary Year' },
+  which_primary_year: {
+    ga: 'An bhliain sa bhunscoil ina bhfuil úsáideoirí',
+    en: 'Wich year of primary school users are in'
+  },
+  secondary_year: { ga: 'An bhliain san iar-bhunscoil', en: 'Post-primary Year' },
+  which_secondary_year: {
+    ga: 'An bhliain san iar-bhunscoil ina bhfuil úsáideoirí',
+    en: 'Wich year of post-primary school users are in'
+  },
+  school_type: { ga: 'Cineál scoile', en: 'School Type' },
+  which_type_primary_secondary: {
+    ga: 'An cineál bunscoile/iar-bhunscoile ina bhfuil na micléinn',
+    en: 'Wich type of primary/secondary school students attend'
+  },
+  third_level_studies: { ga: 'Micléinn tríú leibhéal', en: 'Third Level Studies' },
+  what_third_level_students_study: {
+    ga: 'Ábhair staidéir atá ag micléinn tríú leibhéal',
+    en: 'What third level students are currently studying'
+  },
+  other_studies: { ga: 'Ábhair staidéir eile', en: 'Other studies' },
+  other_third_level_studies: {
+    ga: 'Ábhair staidéir eile nach bhfuil liostaithe',
+    en: 'Other third level studies that are not listed'
+  },
+  third_level_year: { ga: 'An bhliain sa tríú leibhéal', en: 'Third Level Year' },
+  what_third_level_year: {
+    ga: 'What year third level students are currently in',
+    en: 'What year third level students are currently in'
+  },
+  USA_school: { ga: 'USA school', en: 'USA school' },
+  what_students_study_in_USA: {
+    ga: 'What students are currently studying in the USA',
+    en: 'What students are currently studying in the USA'
+  },
+  postgrad_studies: { ga: 'Staidéir iarchéime', en: 'Postgrad Studies' },
+  what_postgrad_studying: {
+    ga: 'Ábhar staidéir na micléinn iarchéime',
+    en: 'What postgrad students are currently studying'
+  },
+  immersion_course: { ga: 'Tumchúrsa', en: 'Immersion Course' },
+  students_attending_immersion_course: {
+    ga: 'An bhfuil na micléinn ag freastal ar thumchúrsa Gaeilge?',
+    en: 'Whether or not students are attending an Irish immersion course'
+  },
+  teacher_school_types: {
+    ga: 'Cineálacha scoileanna ina bhfuil na múinteoirí',
+    en: 'Teacher School Types'
+  },
+  school_level_of_teachers: {
+    ga: 'Leibhéal na scoileanna ina bhfuil na múinteoirí',
+    en: 'What level of schools teachers work in'
+  },
+  teacher_primary_school: { ga: 'Múinteoirí bunscoile', en: 'Teacher Primary School' },
+  type_of_primary_teacher: {
+    ga: 'An cineál scoile ina bhfuil na múinteoirí bunscoile',
+    en: 'What type of primary school teachers work in'
+  },
+  teacher_secondary_school: {
+    ga: 'Múinteoirí iar-bhunscoile',
+    en: 'Teacher Post-Primary school'
+  },
+  type_of_secondary_teacher: {
+    ga: 'An cineál iar-bhunscoile ina bhfuil na múinteoirí',
+    en: 'What type of post-primary school teachers work in '
+  },
+  status_of_native_speakers: {
+    ga: 'Stádas na gcainteoirí dúchasacha',
+    en: 'Status of native speakers'
+  },
+  dialect_preference: {
+    ga: 'Rogha canúna na n-úsáideoirí',
+    en: 'Dialect preference of users'
+  },
+  spoken_comprehension_level: {
+    ga: 'Leibhéal tuisceana ar Ghaeilge labhartha',
+    en: 'Spoken Comprehension Level'
+  },
+  spoken_comprehension_level_of_users: {
+    ga: 'SLeibhéal tuisceana na n-úsáideoirí ar Ghaeilge labhartha',
+    en: 'Spoken comprehension level of users'
+  },
+  other_languages: { ga: 'Teangacha eile', en: 'Other Languages' },
+  other_languages_at_home: {
+    ga: 'Teangacha eile atá in úsáid sa bhaile agus céatadán a n-úsáide',
+    en: 'Other languages spoken at home and percentage of use'
+  },
+  native_tongue_father: { ga: 'Teanga dhúchais an athar', en: 'Native tongue of father' },
+  native_tongue_mother: { ga: 'Teanga dhúchais na máthar', en: 'Native tongue of mother' },
+  years_of_irish: { ga: 'Blianta le Gaeilge', en: 'Years of Irish' },
+  number_of_years_students_study_irish: {
+    ga: 'Cé mhéad blianta atá caite ag micléinn ar staidéar na Gaeilge?',
+    en: 'The number of years students have been studying Irish'
+  },
+  other_language_proficiency: {
+    ga: 'Scileanna i dteangacha eile',
+    en: 'Other Language Proficiency'
+  },
+  other_languages_users_speak: {
+    ga: 'Teangacha eile ina bhfuil úsáideoirí líofa',
+    en: 'Other languages that users speak/are proficient in'
+  },
+  speaking_frequency: { ga: 'Minicíocht a labhartha', en: 'Speaking Frequency' },
+  frequency_users_speak_irish: {
+    ga: 'Minicíocht úsáid na Gaeilge',
+    en: 'Frequency users speak Irish'
+  },
+  speak_with: { ga: 'Céilí comhrá', en: 'Speak With' },
+  with_whom_speak_irish: {
+    ga: 'Daoine a mbíonn úsáideoirí ag labhairt Gaeilge leo',
+    en: 'With whom users normally speak Irish'
+  },
+  irish_media: { ga: 'Na meáin Ghaeilge', en: 'Irish Media' },
+  how_often_media: {
+    ga: 'Na cineálacha meán a bhíonn ag úsáideoirí agus minicíocht a n-úsáide',
+    en: 'Types of Irish media that users use and how often they use it'
+  },
+  irish_reading: { ga: 'Irish Reading', en: 'Irish Reading' },
+  how_often_reading: {
+    ga: 'An cineál léitheoireachta a dhéanann úsáideoirí agus minicíocht na léitheoireachta sin',
+    en: 'Types of Irish reading that users do and how often they use it'
+  },
+  type: { ga: 'Cineál', en: 'Type' },
+  irish_writing: { ga: 'Scríbhneoireacht Ghaeilge', en: 'Irish Writing' },
+  how_often_writing: {
+    ga: 'Cineal scríbhneoireachta a dhéanann úsáideoirí agus cé chomh minic is a dhéanann siad é',
+    en: 'Types of Irish writing that users do and how often they use it'
+  },
+  synth_opinion: { ga: 'Meas ar chaint shintéiseach', en: 'Synth Opinion' },
+  user_opinion_synthetic_voice: {
+    ga: 'Meas na n-úsáideoirí ar chaint shintéiseach',
+    en: 'User opinion on synthetic voices'
+  },
+  messages: { ga: 'Teachtaireachtaí', en: 'Messages' },
+  new_message: { ga: 'Teachtaireacht Nua', en: 'New Message' },
+  new_messages: { ga: 'Teachtaireachtaí Nua', en: 'New Messages' },
+  send_to: { ga: 'Curtha go', en: 'Send to' },
+  from: { ga: 'Ó', en: 'From' },
+  subject: { ga: 'Ábhar', en: 'Subject' },
+  date: { ga: 'Dáta na dteachtaireachtaí', en: 'Date' },
+  no_messages: { ga: 'Níl teachtaireachtaí agat', en: 'You have no messages' },
+  add_to_message: { ga: 'Cuir leis an teachtaireacht', en: 'Add to message' },
+  all_class_members: { ga: 'Gach ball den Rang', en: 'All class members' },
+  stats: { ga: 'Staitisticí', en: 'Stats' },
+  statistics: { ga: 'Staitisticí', en: 'Statistics' },
+  class_statistics: { ga: 'Staitisticí Ranga', en: 'Class Statistics' },
+  individual_statistics: {
+    ga: 'Staitisticí an Dalta Aonair',
+    en: 'Individual Student Statistics'
+  },
+  classroom_statistics: { ga: 'Staitisticí Ranga', en: 'Classroom Statistics' },
+  grammar_errors: { ga: 'Earráidí Gramadaí', en: 'Grammar Errors' },
+  edit_grammar_errors: {
+    ga: 'Déan eagarthóireacht ar na hearráidí gramadaí',
+    en: 'Edit Grammar Errors'
+  },
+  total_grammar_errors: { ga: 'Iomlán na nEarráidí Gramadaí', en: 'Total Grammar Errors' },
+  select_all: { ga: 'Roghnaigh Gach Rud', en: 'select all' },
+  dictionary: { ga: 'Foclóir', en: 'Dictionary' },
+  recordings: { ga: 'Taifeadadh', en: 'Recordings' },
+  recording: { ga: 'Taifeadadh', en: 'Recording' },
+  go_to_archive: { ga: 'Téigh go Cartlann', en: 'Go to Archive' },
+  archive_recording: { ga: 'Cuir Taifead sa Chartlann', en: 'Archive Recording' },
+  archive: { ga: 'Cartlann', en: 'Archive' },
+  save_changes_made_to_this_recording: {
+    ga: 'Sábháil athruithe a rinneadh don taifeadadh seo?',
+    en: 'Save changes made to this recording?'
+  },
+  recordings_archive: { ga: 'Taifid sa Chartlann', en: 'Recordings Archive' },
+  listen_record_compare: {
+    ga: 'Éist, Déan taifead agus Déan comparáid',
+    en: 'Listen, Record, and Compare'
+  },
+  listen_and_compare: { ga: 'Éist agus Déan Comparáid', en: 'Listen and Compare' },
+  general: { ga: 'Ginearálta', en: 'General' },
+  word_choice: { ga: 'Rogha Focal', en: 'Word Choice' },
+  Unrecognised_word: { ga: 'Focal Anaithnid', en: 'Unrecognised Word' },
+  prefix: { ga: 'Réimir', en: 'Prefix' },
+  lenition: { ga: 'Séimhiú', en: 'Lenition' },
+  eclipsis: { ga: 'Urú', en: 'Eclipsis' },
+  language_specific: { ga: 'Sainiúil don Teanga', en: 'Language Specific' },
+  delete_my_account: { ga: 'Scrios mo chuntas', en: 'Delete my account' },
+  delete_this_account: { ga: 'Scrios an cuntas seo', en: 'Delete this account' },
+  are_you_sure: {
+    ga: 'An bhfuil tú cinnte go bhfuil tú ag iarraidh do chuntas a scrios?',
+    en: 'Are you sure you want to delete your account?'
+  },
+  this_includes_story_data: {
+    ga: ' Tá na scéalta agus na sonraí staitistiúla go léir san áireamh leis seo',
+    en: 'This includes all saved stories and statistical data'
+  },
+  this_includes_personal_data: {
+    ga: 'Tá na sonraí pearsanta agus na sonraí ranga go léir san áireamh leis seo',
+    en: 'This includes all personal and classroom data'
+  },
+  user_guide: { ga: "Treoir d'Úsáideoirí", en: 'User Guide' },
+  academic_paper: { ga: 'Foilseachán Acadúil', en: 'Academic Paper' },
+  what_is_an_scealai: { ga: 'Cad é An Scéalaí?', en: 'What is An Scéalaí?' },
+  about_content_text: {
+    ga: 'Áis nua ríomhbhunaithe d’fhoghlaimeoirí na Gaeilge is ea ‘An Scéalaí’. Tugann sé ardán dóibh chun téacsanna nó scéalta a scríobh agus a cheartú. Ceann de na gnéithe nua a bhaineann leis ná go léann sé a scéal féin ar ais don fhoghlaimeoir. Anuas air seo aimsíonn sé botúin ghramadaí agus botúin litrithe a d’fhéadfadh a bheith sa téacs. Is féidir tuilleadh eolais a fháil faoin dtáb ‘teicneolaíocht’ ar ár suíomh gréasáin (www.abair.tcd.ie/scealai). Is cuid dár dtionscadal taighde anseo i Scoil na nEolaíochtaí Teangeolaíochta, Urlabhra agus Cumarsáide, Coláiste na Tríonóide, é An Scéalaí, áit a bhfuilimid ag fiosrú na héifeachta a bhaineann le modhanna éagsúla foghlama teangacha. Ba mhaith linn go mbainfeadh sibh triail as profáil ó chluas chomh maith leis an seiceálaí gramadaí chun botúin a aimsiú is a cheartú sna scéalta. Beidh sé seo ina chabhair dúinne anseo i gColáiste na Tríonóide freisin agus sinn ag cur lenár n- áiseanna foghlama, ach thar aon ní eile ba mhaith linn go mbainfeadh na foghlaimeoirí taitneamh agus tairbhe as.',
+    en: 'An Scéalaí is an online learning platform for students of the Irish language. It provides an environment in which users can write and correct Irish texts, or stories. One of An Scéalaí ’s unique features is the ability to listen back to a computer-generated voice reading your story as Gaeilge. As well as this, users can run their story through a grammar-checker that highlights any spelling mistakes or other grammatical errors found in the text. More detail on these technologies can be found at the Technology tab on our website.\n' +
+      '\n' +
+      'An Scéalaí also serves as a research project by Trinity College Dublin, investigating the effectiveness of different language-learning methods. We invite you to try using audio check as well as grammar check to correct spelling and grammar mistakes in your stories. This will provide us with useful data to help design language-learning resources in the future!\n' +
+      '\n' +
+      'You can contact us with any queries/feedback at scealai.info@gmail.com'
+  },
+  neasa1: {
+    ga: 'Is Ollamh Cúnta Ussher le Teicneolaíocht Urlabhra agus Teanga don Ghaeilge í Neasa Ní Chiaráin i <a href="https://www.tcd.ie/slscs/" target="_blank" rel="noopener noreferrer"> Scoil na nEolaíochtaí Teangeolaíochta, Urlabhra agus Cumarsáide, Coláiste na Tríonóide</a>.  Tá sí ag obair le fada ar fhobairt na teicneolaíochta urlabhra mar bhall de thionscadal <a href="https://www.abair.tcd.ie/" target="_blank" rel="noopener noreferrer">ABAIR</a> sa <a href="https://www.tcd.ie/slscs/clcs/psl/index.php" target="_blank" rel="noopener noreferrer">tSaotharlann Foghraíochta agus Urlabhra</a>. Chomh maith le hobair ar na bunacmhainní teangeolaíochta a bhfuil gá leo do shintéis na cainte, díríonn a cuid taighde ar an teicneolaíocht urlabhra agus teanga i gcomhthéacs na <b>Foghlama Ríomhchuidithe Teangacha cliste (iCALL)</b>, go háirithe do mhúineadh/d’fhoghlaim na Gaeilge.<br><br> Féach <a href="https://wakelet.com/wake/e9a86424-beb7-4aa2-9882-a671899691de/edit" target="_blank" rel="noopener noreferrer">anseo</a> le haghaidh a thuilleadh imeachtaí atá ar bun sa réimse seo',
+    en: 'Neasa Ní Chiaráin is Ussher Assistant Professor of Irish Speech and Language Technology in the <a href="https://www.tcd.ie/slscs/" target="_blank" rel="noopener noreferrer"> School of Linguistic, Speech and Communication Sciences</a>.  She has been working for many years as part of the ABAIR initiative in the <a href="https://www.tcd.ie/slscs/clcs/psl/index.php" target="_blank" rel="noopener noreferrer">Phonetics & Speech Lab., CLCS</a>, on the development of Irish language speech technologies (see  <a href="https://www.abair.tcd.ie/" target="_blank" rel="noopener noreferrer">www.abair.ie</a>). As well as working on the development of the underpinning linguistic resources needed for synthesis, her research focuses on exploring the application of speech and language technology in an intelligent <b>Computer-Assisted Language Learning (iCALL)</b><br><br> See more of the activities ongoing in the area <a href="https://wakelet.com/wake/" target="_blank" rel="noopener noreferrer">here</a>:'
+  },
+  neasa2: {
+    ga: 'Is ábhar spéise é do thaighde Neasa an t-idirbhealach idir uirlisí digiteacha le hIntleacht Shaorga, teicneolaíocht na hurlabhra go háirithe, agus an tacaíocht gur féidir leo seo a thabhairt do mhúineadh agus d’fhoghlaim teangacha. Is í aidhm na taighde ná an mheicníocht atá taobh thiar de mhúineadh/d’fhoghlaim teangacha a iniúchadh agus fiosrú a dhéanamh ar na slite gur féidir leis an teicneolaíocht cabhrú leis an bpróiséas. I measc na mbuncheisteanna ina cuid taighde tá:',
+    en: 'Neasa’s research interest lies at the intersection between the use of methods such as AI and digital tools, particularly speech technology, and the support of language teaching and learning. '
+  },
+  neasa2_point1: {
+    ga: 'Cén saghas uirlisí atá éifeachtach chun tacú le múineadh agus le foghlaim teangacha?',
+    en: 'What makes effective tools for language learning and teaching?'
+  },
+  neasa2_point2: {
+    ga: 'Cén úsáid ar féidir linn a bhaint as an teicneolaíocht chun cabhrú le forás teanga?',
+    en: 'How can we use technology to support language growth?'
+  },
+  neasa3: {
+    ga: 'Bíonn an tuiscint atá againn ar mhodhanna múinte agus ar mhodhanna foghlama teangacha de shíor ag forbairt. Tá sé mar aidhm ag an taighde seo ceannródaíocht a thabhairt d’úsáid na teicneolaíochta mar áis theagasc teangacha, don Ghaeilge go háirithe.',
+    en: 'Our understanding of language teaching/learning methodologies is in a constant state of development and this research aims to be at the cutting edge in the use of technology to complement language teaching, Irish in particular. '
+  },
+  neasa4: {
+    ga: 'Trí úsaid a bhaint as teicneolaíocht na hurlabhra is nua-aimseartha, tá sé ar ár gcumas anois tosú ar chórais a thógáil a bheadh idirghníomhach agus curtha in oiriúint do chuinsí éagsúla foghlama. Nascfaidh na córais seo modhanna atá bunaithe ar phróiseáil teanga leis na tuiscintí atá againn ar theangacha a shealbhú.  Ta se d’aidhm againn iniúchadh a dhéanamh ar:',
+    en: 'By exploiting state-of-the-art speech and language technologies for Irish we can now start to look at building adaptive and interactive systems, combining natural language processing methods with second language acquisition insights. We aim to investigate:'
+  },
+  neasa4_point1: {
+    ga: 'na deiseanna a bheadh ann ábhar a chur in oiriúint don duine aonair (ag glacadh leis go leanann patrún ar leith na céimeanna éagsúla foghlama teanga)',
+    en: 'opportunities to individualise content (supporting the general goals of certain learning sequences in the language) '
+  },
+  neasa4_point2: {
+    ga: 'na sainstruchtúir theanga atá sa Ghaeilge atá riachtanach chun foirm agus feidhm a chur i dtoll a chéile',
+    en: 'certain Irish target constructions central to the acquisition process and integration of form and function'
+  },
+  neasa4_point3: {
+    ga: 'na slite is éifeachtaí atá ann chun seans a thabhairt d’fhoghlaimeoirí an teanga a chleachtadh agus líofacht a bhaint amach',
+    en: 'how best to give learners the opportunity to practice and to achieve fluency'
+  },
+  neasa4_point4: {
+    ga: 'an timpeallacht is éifeachtaí a chruthú chun go bhfeidhmeoidh córais chliste teagaisc',
+    en: 'the building of effective intelligent language learning environments and intelligent tutoring systems'
+  },
+  neasa5: {
+    ga: 'Ba chuid é den phlean a bhain leis An Scéalaí ón tús ná faisnéis a bhailiú faoi fhoghlaim teangacha. Cé go bhfuil a dhearadh agus a thógáil fós idir lámha, ag an am céanna táimid ag an bpointe chun gur féidir linn grinndearcadh a dhéanamh ar an bpróiseas a bhaineann le foghlaim teangacha agus taighde atá fianaise-bhunaithe a dhéanamh air. Déanfar é seo trí:',
+    en: 'At the outset An Scéalaí was planned as a platform to explore evidence for language learning. By designing and building An Scéalaí (while still at a developmental stage) we are now in a position to look closely at the process of language acquisition, as established from firm evidence-based research, by:'
+  },
+  neasa5_point1: {
+    ga: 'shamplaí de theanga na bhfoghlaimeoirí a bhailiú agus anailís a dhéanamh orthu',
+    en: 'collecting and analysing learner language'
+  },
+  neasa5_point2: {
+    ga: 'chéimeanna éagsúla forbartha a mhapáil',
+    en: 'mapping language development stages'
+  },
+  neasa5_point3: {
+    ga: 'thaighde a dhéanamh ar an éifeacht a bhíonn ag na tascanna foghlama a thugtar d’fhoghlaimeoirí ar an bhforbairt a dhéanann siad',
+    en: 'exploring how task design may influence language development'
+  },
+  neasa6: {
+    ga: 'Tá sé d’aidhm againn freisin féachaint ar an éifeacht a bhíonn ag aiseolas ar fhoghlaimeoirí agus ar an saghas aiseolais is fearr a thabhairt chun iad a dhíriú go dtí an chéad chéim eile dá bhforbairt.',
+    en: 'We also aim to examine the nature of effective feedback and look at what constitutes suitable correction mechanisms for learners so that they may be directed towards their next step in the development ladder.'
+  },
+  neasa7: {
+    ga: '<br>Is áis thábhachtach é <i>An Scéalaí</i> don fhoghlaimeoir agus don taighdeoir araon. Is ceannródaí é don Ghaeilge. Cuireann sé ar ár gcumas timpeallacht chinnte fhoghlama a chruthú – ceann a bheidh de shíor ag forbairt agus é bunaithe ar fhíor-shonraíocht ó fhíor-fhoghlaimeoirí!',
+    en: '<br><i>An Scéalaí </i>is an important tool both for the learner and the researcher. It is the first of its kind for Irish. It enables us to create a solid learning environment for learners which will continuously evolve and develop informed by real data from real learners. '
+  },
+  meet_the_developers: {
+    ga: 'Seo agaibh na Forbróirí Gréasáin…',
+    en: 'Meet the <i>An Scéalaí</i> platform developers… '
+  },
+  meet_the_investigator: {
+    ga: 'Seo í an Príomhthaighdeoir:',
+    en: 'Meet the Principal Investigator…'
+  },
+  meet_the_artist: { ga: 'Seo agaibh an tEalaíontóir…', en: 'Meet the Artist… ' },
+  meet_the_abair_team: { ga: '…Agus Foireann ABAIR.ie', en: 'Meet the ABAIR.ie team…' },
+  maddie_bio: {
+    ga: 'Is i Weatherford, TX, sna Stáit Aontaithe a tógadh Madeleine ach bhog sí go Baile Átha Cliath chun freastal ar Choláiste na Tríonóide agus céim a dhéanamh san Eolaíocht Ríomhaireachta agus Teanga. Bhí Fraincis, Teangeolaíochta agus Ríomhaireacht aici mar ábhair staidéir ar an gcúrsa seo. Chaith sí bliain (2019-2020) i Lyon na Fraince, áit a ndearna sí staidéar ar an ríomhaireacht i Scoil na hInnealtóireachta, INSA, chomh maith le teangeolaíocht in Université Lyon 2 Lumière. Thosaigh sí ag obair ar <i>An Scéalaí</i> in 2020 agus ag cur leis an taobh tosaigh agus an cúltaobh chomh maith le hanailís a dhéanamh ar shonraí a bailíodh ó húsáideoirí. Tá sí ag súil lena céim a chríochnú faoin bhFómhar 2021 agus leanúint ina dhiaidh sin chun cúrsa máistreachta a dhéanamh sa ríomhtheangeolaíocht.',
+    en: 'Madeleine grew up in Weatherford, TX, USA, but she moved to Dublin to begin her studies as a Computer Science and Language undergraduate student at Trinity College Dublin, a course which combines studies in computer science, French, and linguistics. She spent a year (2019-2020) in Lyon, France studying computer science at the engineering school INSA as well as linguistics at the Université Lyon 2 Lumière.  She began working with <i>An Scéalaí</i> in 2020, developing the frontend and backend in addition to analysing the data collected from users.  She is planning to graduate in the fall of 2021 and hopes to continue working or pursue a master in a computational linguistics related field.'
+  },
+  oisin_bio: {
+    ga: 'Mac léinn i gColáiste na Tríonóide é Oisín agus tá sé sa bhliain dheiridh dá bhunchéim san Eolaíocht Ríomhaireachta agus Teanga. D’fhás sé suas i Maigh Nuad, áit ar fhreastail sé ar an mbunscoil lán-Ghaelach. Thosaigh Oisín ag obair ar <i>An Scéalaí</i> an samhradh seo caite, ag tabhairt leagan píolótach den ardán suas chun dáta. D’fhan sé ag obair ar an tionscadal go páirt-aimseartha le linn a thréimhse Erasmus nuair a bhí sé i Lyon na Fraince. Anuas ar a chuid oibre sa tSaotharlann Foghraíochta agus Urlabhra, bhí intéirneacht aige le Google, Zurich agus Ionad Taighde ADAPT i gColáiste na Tríonóide. Tar éis na bunchéime, tá sé beartaithe ag Oisín leanúint lena chuid staidéir ar an Ríomhtheangeolaíocht ag leibhéal iarchéime. ',
+    en: "Oisín is a student at Trinity College, currently entering the final year of his bachelor's degree in Computer Science & Language. Growing up in Maynooth, Co. Kildare, he attended a gaelscoil for his primary education. Oisín started developing <i>An Scéalaí </i> last summer, modernising a previous iteration of the app. He continued working part-time on the project throughout his Erasmus exchange in Lyon, France. In addition to his work at the Phonetics & Speech Lab, Oisín has completed internships at Google, Zurich and the ADAPT Research Centre, Trinity College Dublin. Upon finishing his undergraduate degree, Oisín hopes to continue studying Computational Linguistics at postgraduate level."
+  },
+  anna_bio: {
+    ga: 'As São Paulo na Brasaíle í Anna, agus bhain sí céim amach sna hAmharc-ealaíona agus Stair na hEalaíne in Ollscoil Brown. Bhí Gearmáinis aici mar fho-ábhar agus spéis aici i dteangacha an domhain ó bhí sí an-óg. D’fhoghlaim sí Seapáinis agus í sa mheánscoil. Tar éis a blianta Ollscoile chuaigh sí ag obair le comhlacht foilsitheoireachta mar mhaisitheoir leabhar agus ag an am céanna rinne sí cúrsaí i mbeochan íomhána, ealaín thraidisiúnta agus Rúisis. Tháinig sí go Coláiste na Tríonóide don gclár M.Phil. i bPróiseáil na hUrlabhra agus Teanga agus thug sí isteach a tráchtas ar Urlabhra Mothaitheach in 2020. Tá sí chun leanúint lena cuid staidéir sa réimse seo agus í díreach tosaithe ar PhD. Tá an Ghaeilge aici mar ábhar staidéir chomh maith.',
+    en: 'Originally from São Paulo, Brazil, Anna has a Bachelors in Visual Arts and Art History from Brown University, where she also minored in German due to an interest in world languages from a young age. Having learned Japanese during high school, she spent the following years after graduation working in publishing and as a freelance illustrator and taking courses in animation, traditional art and Russian. She then entered the MPhil program in Speech and Language Processing at Trinity College Dublin and, having submitted her dissertation in Affective Speech in 2020, is continuing research in this field while studying Irish on the side.'
+  },
+  abair_bio: {
+    ga: 'Tá an obair seo ar fad ar siúl i gcomhpháirt leis an tionscadal ABAIR.ie sa tSaotharlann Foghraíochta agus Urlabhra. Ní bheadh sí indéanta gan an tacaíocht ón bhfoireann sároillte teangeolaithe, ríomheolaithe agus innealtóirí urlabhra. Féach suíomh Gréasáin ABAIR <a href="https://www.abair.tcd.ie/ga/" target="_blank" rel="noopener noreferrer">anseo</a>:',
+    en: 'This work is carried out as part of the ABAIR initiative in the Phonetics and Speech Lab. and wouldn’t be possible without the collaboration with and constant backup from the talented team of linguistics, computer scientists and speech engineers. See the ABAIR initiative homepage <a href="https://www.abair.tcd.ie/ga/" target="_blank" rel="noopener noreferrer">here</a>: '
+  },
+  abair_pic_description: {
+    ga: 'An tSaotharlann Foghraíochta agus Urlabhra, Scoil na nEolaíochtaí Teangeolaíochta, Urlabhra agus Cumarsáide, Coláiste na Tríonóide',
+    en: 'The team at the Phonetics and Speech Lab., School of Linguistic, Speech and Communication Sciences, TCD'
+  },
+  story_examples: {
+    ga: 'Samplaí - scéalta Gaeilge i bhfoirm LARA',
+    en: 'Story Examples - Irish texts available in LARA form'
+  },
+  story_bank_growing: {
+    ga: 'Tá an banc scéalta ag fás. Cruthaigh cuntas le An Scéalaí le teacht ar tuilleadh scéalta',
+    en: 'The story bank is growing. Create an account with An Scéalaí to find out more stories'
+  },
+  higher_level: { ga: 'Ardleibhéal', en: 'Higher Level' },
+  gweedore: { ga: 'Guth Ghaoth Dobhair', en: 'Voice of Gweedore' },
+  mumhan: { ga: 'Guth na Mumhan', en: 'Voice of Mumhan' },
+  leaving_cert_stories: {
+    ga: 'Prós Comónta Ainmnithe don Ardteistiméireacht',
+    en: 'Leaving Certificate Common Prose'
+  },
+  leaving_cert_prose: {
+    ga: 'Prós: scéalta atá ar shiollabas na hArdteistiméireachta',
+    en: 'Prose: stories on the Leaving Certificate syllabus'
+  },
+  other_stories: { ga: 'Scéalta Eile', en: 'Other Stories' },
+  chonamara: { ga: 'Guth Chonamara', en: 'Voice of Chonamara' },
+  view_story: { ga: 'Léigh an Scéal', en: 'View Story' },
+  sign_in_to_view_more: {
+    ga: 'Sínigh isteach le tuilleadh scéalta a léamh!',
+    en: 'Sign in to view more stories!'
+  },
+  more_resources: { ga: 'Acmhainní breise', en: 'More resources' },
+  simple_versions_old_stories: {
+    ga: 'Leaganacha simplí de sheanscéalta',
+    en: 'Simple versions of old stories'
+  },
+  published_courtesy_of: {
+    ga: 'Foilsithe anseo le caoinchead ó',
+    en: 'Published with the courtesy of'
+  },
+  beathna_na_feinne1: {
+    ga: 'Ba é Fionn Mac Cumhaill agus na Fianna na laochra ba mhó i mbéaloideas na hÉireann agus bhí leaganacha éagsúla de na heachtraí a bhain leo le fáil ar fud na tíre. D’fhág siad a rian ar stair na hÉireann mar eiseamláirí den uaisleacht, den chrógacht agus den neart. ‘Bráithreachas na bhFíníní’ a tugadh ar an eagraíocht réabhlóideach a bunaíodh i Meiriceá in 1858. Tá Fianna Fáil ann agus Fianna Éireann. Úsáidtear é mar bhriathar ‘ag fiannaíocht’ – ag insint scéalta fiannaíocht, nó ag insint scéalta gan dealramh (le searbhas).',
+    en: 'Ba é Fionn Mac Cumhaill agus na Fianna na laochra ba mhó i mbéaloideas na hÉireann agus bhí leaganacha éagsúla de na heachtraí a bhain leo le fáil ar fud na tíre. D’fhág siad a rian ar stair na hÉireann mar eiseamláirí den uaisleacht, den chrógacht agus den neart. ‘Bráithreachas na bhFíníní’ a tugadh ar an eagraíocht réabhlóideach a bunaíodh i Meiriceá in 1858. Tá Fianna Fáil ann agus Fianna Éireann. Úsáidtear é mar bhriathar ‘ag fiannaíocht’ – ag insint scéalta fiannaíocht, nó ag insint scéalta gan dealramh (le searbhas).'
+  },
+  beathna_na_feinne2: {
+    ga: 'Sa scéal seo bualann Naomh Pádraig le Caoilte, duine de na Fianna. De gháth is é Oisín a bhualann le Pádraig mar atá i Laoithe na Féinne a chuir An Seabhac in eagar. Tá cur síos sa sliocht seo ar an saol a bhí ag na Fianna agus tá codarsnacht idir sin agus an creideamh nua nó an Chríostaíocht. Tá cur síos anseo ar na nósanna seilge a bhí acu agus mar a chaith siad a gcuid bia. Tá cur síos maith ann ar na tréithe a bhain leis na Fianna agus mar a cláraíodh mar bhall de na Fianna tú. Gaiscíoch ab ea gach aon duine acu agus níl insint scéil ar a gcumas, a neart agus a gcrógacht.',
+    en: 'Sa scéal seo bualann Naomh Pádraig le Caoilte, duine de na Fianna. De gháth is é Oisín a bhualann le Pádraig mar atá i Laoithe na Féinne a chuir An Seabhac in eagar. Tá cur síos sa sliocht seo ar an saol a bhí ag na Fianna agus tá codarsnacht idir sin agus an creideamh nua nó an Chríostaíocht. Tá cur síos anseo ar na nósanna seilge a bhí acu agus mar a chaith siad a gcuid bia. Tá cur síos maith ann ar na tréithe a bhain leis na Fianna agus mar a cláraíodh mar bhall de na Fianna tú. Gaiscíoch ab ea gach aon duine acu agus níl insint scéil ar a gcumas, a neart agus a gcrógacht.'
+  },
+  colorado1: {
+    ga: 'Seo sliocht as gearrscéal le Máire Séamus Ó Grianna as Rann na Feirste i nGaeltacht Thír Chonaill. …d’úsáid sé ‘Máire’ mar ainm cleite. Duine de mhór-scríbhneoirí na Gaeilge ba ea é (1889-1969).',
+    en: 'Seo sliocht as gearrscéal le Máire Séamus Ó Grianna as Rann na Feirste i nGaeltacht Thír Chonaill. …d’úsáid sé ‘Máire’ mar ainm cleite. Duine de mhór-scríbhneoirí na Gaeilge ba ea é (1889-1969).'
+  },
+  colorado2: {
+    ga: 'Ba ghnách le daoine as iarthar Thír Chonaill dul ag obair ar thailte méithe Thír Eoghain nó cois Lagáin. Théidis go hAlbain freisin. Thosaidís ag aois an-óg, ó aois a dhá bhliain déag ar aghaidh, agus bhídís ag obair ar na feirmeacha agus ba bhocht, dearóil an saol a bhí acu. Is minic a bhíodh cónaí orthu i mbothy nó scioból. Is uaidh sin a tháinig an t-ainm “The Bothy Band”. Tugann an píosa seo blas dúinn ar an saghas saoil a bhí ag na sclábhaithe bochta seo.         Léiríonn sé freisin an gá a bhí le Béarla agus an meas a bhí ag na daoine ar Bhéarla galánta.',
+    en: 'Ba ghnách le daoine as iarthar Thír Chonaill dul ag obair ar thailte méithe Thír Eoghain nó cois Lagáin. Théidis go hAlbain freisin. Thosaidís ag aois an-óg, ó aois a dhá bhliain déag ar aghaidh, agus bhídís ag obair ar na feirmeacha agus ba bhocht, dearóil an saol a bhí acu. Is minic a bhíodh cónaí orthu i mbothy nó scioból. Is uaidh sin a tháinig an t-ainm “The Bothy Band”. Tugann an píosa seo blas dúinn ar an saghas saoil a bhí ag na sclábhaithe bochta seo.         Léiríonn sé freisin an gá a bhí le Béarla agus an meas a bhí ag na daoine ar Bhéarla galánta.'
+  },
+  druma_mor1: {
+    ga: 'Sliocht as an úrscéal An Druma Mór le Seosamh Mac Grianna é seo.',
+    en: 'Sliocht as an úrscéal An Druma Mór le Seosamh Mac Grianna é seo.'
+  },
+  druma_mor2: {
+    ga: 'Seo léiriú ar shaol na ndaoine sna Rosainn i nGaeltacht Thír Chonaill breis is céad bliain ó shin. Tá an scéal bunaithe ar Lá le Pádraig agus an pharáid a bhí ag muintir an bhaile. Bhidís an-bhródúil as a gcumas ceoil agus ba chúis mórtais é a bheith i seilbh an druma mhóir.',
+    en: 'Seo léiriú ar shaol na ndaoine sna Rosainn i nGaeltacht Thír Chonaill breis is céad bliain ó shin. Tá an scéal bunaithe ar Lá le Pádraig agus an pharáid a bhí ag muintir an bhaile. Bhidís an-bhródúil as a gcumas ceoil agus ba chúis mórtais é a bheith i seilbh an druma mhóir.'
+  },
+  druma_mor3: {
+    ga: '“An lá roimhe sin, ní raibh iontu ach fir spáide ar pháirceanna cúnga, ach an lá seo bhí siad chomh stuama le dáil agus chomh mór-luachach le heaspaigh, agus chomh scáfar agus chomh tintrí le harm” (lth. 19).',
+    en: '“An lá roimhe sin, ní raibh iontu ach fir spáide ar pháirceanna cúnga, ach an lá seo bhí siad chomh stuama le dáil agus chomh mór-luachach le heaspaigh, agus chomh scáfar agus chomh tintrí le harm” (lth. 19).'
+  },
+  druma_mor4: {
+    ga: 'Bhí idir Phágántacht agus Chríostaíocht ag roinnt leis an ócáid.',
+    en: 'Bhí idir Phágántacht agus Chríostaíocht ag roinnt leis an ócáid.'
+  },
+  druma_mor5: {
+    ga: 'Sa sliocht seo bhí Proinsias ag obair thall in Albain. Chuireadh sé airgead abhaile go dtí a mháthair uair nó dhó sa mhí. Bhí léamh agus scríobh (de shaghas) an Bhéarla aige agus is as Béarla a scríobhadh sé. Ní raibh léamh ná scríobh na Gaeilge ag mórán sna Gaeltachtaí ag an am.',
+    en: 'Sa sliocht seo bhí Proinsias ag obair thall in Albain. Chuireadh sé airgead abhaile go dtí a mháthair uair nó dhó sa mhí. Bhí léamh agus scríobh (de shaghas) an Bhéarla aige agus is as Béarla a scríobhadh sé. Ní raibh léamh ná scríobh na Gaeilge ag mórán sna Gaeltachtaí ag an am.'
+  },
+  druma_mor6: {
+    ga: 'Théadh Beagaide go buachaill óg a bhí ina chónaí in aice léi chun na litreacha a léamh agus a scríobh di. Feicimid cuid de na fadhbanna a bhí ag an mbuachaill leis an aistriúchán anseo.',
+    en: 'Théadh Beagaide go buachaill óg a bhí ina chónaí in aice léi chun na litreacha a léamh agus a scríobh di. Feicimid cuid de na fadhbanna a bhí ag an mbuachaill leis an aistriúchán anseo.'
+  },
+  balor1: {
+    ga: 'Tá Balor an-mhór i mbéaloideas na hÉireann agus i mbéaloideas Thír Chonaill, ach go háirithe. Balor na Súile Nimhe is mó a thugtar air mar go raibh súil aige i lár a éadain a churfeadh an domhan trí thine. Ba é a bhí ina cheannaire ar na Fothmhuireáin, nó an dream a raibh cónaí orthu ag bun na farraige agus a dheineadh ionsaí, ár agus scrios ar thalamh na hÉireann. Ba iad an Tuatha Dé Danainn cosantóirí na tíre agus de réir an tseanchais is leo a thit Balor ar deireadh ag Cath Mhaighe Tuireadh. Ba é a gharmhac, Lugh an Láimh Fhada, a mharaigh é.',
+    en: 'Tá Balor an-mhór i mbéaloideas na hÉireann agus i mbéaloideas Thír Chonaill, ach go háirithe. Balor na Súile Nimhe is mó a thugtar air mar go raibh súil aige i lár a éadain a churfeadh an domhan trí thine. Ba é a bhí ina cheannaire ar na Fothmhuireáin, nó an dream a raibh cónaí orthu ag bun na farraige agus a dheineadh ionsaí, ár agus scrios ar thalamh na hÉireann. Ba iad an Tuatha Dé Danainn cosantóirí na tíre agus de réir an tseanchais is leo a thit Balor ar deireadh ag Cath Mhaighe Tuireadh. Ba é a gharmhac, Lugh an Láimh Fhada, a mharaigh é.'
+  },
+  balor2: {
+    ga: 'Ní hé sin an leagan den scéal atá ar fáil i gceantair éagsúla i dTír Chonaill, áfach. Is gnáthrud é seo mar is ó bhéal a lean na scéalta ó ghlúin go glúin agus chuir na scéalaithe iad in oiriúint dá lucht éisteachta. Bhíodh na scéalta suite sna ceantair a raibh cur amach ag na daoine orthu.',
+    en: 'Ní hé sin an leagan den scéal atá ar fáil i gceantair éagsúla i dTír Chonaill, áfach. Is gnáthrud é seo mar is ó bhéal a lean na scéalta ó ghlúin go glúin agus chuir na scéalaithe iad in oiriúint dá lucht éisteachta. Bhíodh na scéalta suite sna ceantair a raibh cur amach ag na daoine orthu.'
+  },
+  balor3: {
+    ga: 'Sa scéal seo bhí a dhún ag Balor ar Oileán Thoraí – dún atá le feiceáil go fóill i measc na gcarraigeacha in oirthear an oileáin. Bhí sé sa tairngreacht go dtitfeadh Balor ag lámh a gharmhic féin. Cheap Balor go bhféadfadh sé an ceann is fearr a fháil ar an tairngreacht – rud nach féidir a dhéanamh – agus chuir sé a iníon i Lios léi féin ar Thoraí. Theip ar an bplean sin. Feicimid mórthéamaí na scéalaíochta sa scéal beag seo – ruathair ar an mórthír, an chumhacht a bhí ina shúil, an bhó a goideadh, ár agus díothas.',
+    en: 'Sa scéal seo bhí a dhún ag Balor ar Oileán Thoraí – dún atá le feiceáil go fóill i measc na gcarraigeacha in oirthear an oileáin. Bhí sé sa tairngreacht go dtitfeadh Balor ag lámh a gharmhic féin. Cheap Balor go bhféadfadh sé an ceann is fearr a fháil ar an tairngreacht – rud nach féidir a dhéanamh – agus chuir sé a iníon i Lios léi féin ar Thoraí. Theip ar an bplean sin. Feicimid mórthéamaí na scéalaíochta sa scéal beag seo – ruathair ar an mórthír, an chumhacht a bhí ina shúil, an bhó a goideadh, ár agus díothas.'
+  },
+  mar_a_baisteadh_fionn1: {
+    ga: 'Seo scéal as Leabhar Sheáin Uí Chonaill a chuir Séamas Ó Duilearga in eagar. Bailíodh na scéalta seo idir 1923-1931. Is in Uíbh Ráthach i gCo. Chiarraí a bhí cónaí ar Sheán Ó Conaill, ceantar a bhí ina Ghaeltacht láidir ag an am. ',
+    en: 'Mar a Baisteadh Fionn recounts a story about Fionn MacCumhaill, the most important person in the Fenian cycle of Irish mythology. This short piece was adapted from an oral collection done in South West Kerry in the 1920s. It retains many of the characteristics of the oral tradition, making it particularly suitable as a text that should be presented in an oral format'
+  },
+  mar_a_baisteadh_fionn2: {
+    ga: 'Ceann eile de na scéalta Fiannaíochta é seo agus arís leagan logánta den scéal atá ann. Suimiúil go n-úsáidtear an téarma ‘baisteadh’ toisc go mbaineann sé le tréimhse réamh-Chríostaíochta.',
+    en: 'Ceann eile de na scéalta Fiannaíochta é seo agus arís leagan logánta den scéal atá ann. Suimiúil go n-úsáidtear an téarma ‘baisteadh’ toisc go mbaineann sé le tréimhse réamh-Chríostaíochta.'
+  },
+  mar_a_baisteadh_fionn3: {
+    ga: 'Feicimid sa scéal seo an tábhacht a bhí ag tairngreacht agus dá mbeadh rud éigin ráite ag na daoine mar thairngreacht ní raibh aon teacht timpeall air sin. Sa chás seo rinne an rí a sheacht ndícheall an ríocht a choimeád ina shliocht féin agus níorbh é sin a bhí i ndán dó. Tá macalla de scéalta ón mBíobla le blas anseo. ',
+    en: 'Feicimid sa scéal seo an tábhacht a bhí ag tairngreacht agus dá mbeadh rud éigin ráite ag na daoine mar thairngreacht ní raibh aon teacht timpeall air sin. Sa chás seo rinne an rí a sheacht ndícheall an ríocht a choimeád ina shliocht féin agus níorbh é sin a bhí i ndán dó. Tá macalla de scéalta ón mBíobla le blas anseo. '
+  },
+  mar_a_baisteadh_fionn4: {
+    ga: 'Tá roinnt mhaith de théamaí móra na Fiannaíochta le fáil anseo – an bhrúidiúlacht, an ghaiscíocht, agus an draíocht, gan chaint ar an iomáint. Ba é seo an chéad ghaisce a rinne Fionn.',
+    en: 'Tá roinnt mhaith de théamaí móra na Fiannaíochta le fáil anseo – an bhrúidiúlacht, an ghaiscíocht, agus an draíocht, gan chaint ar an iomáint. Ba é seo an chéad ghaisce a rinne Fionn.'
+  },
+  fairceallach1: {
+    ga: 'Ceann de na scéaltacha móráltachta i measc na Scéalta Fiannachta é seo. Chuirfeadh sé fabhalscéalta Aesop i gcuimhne duit. Níl aon chaint ann ar an ngaiscíocht ná ar thréithe na Féinne. Léiriú atá anseo ar na ceisteanna móra a bhíonn os comhair an uile dhuine. Ní féidir leat éalú uait féin. Bíonn do choinsias nó do dhia ag faire ort i gcónaí cé go gcoimeádann sé/sí siar uait a fhad a bhíonn tú i mbun do chuid cúramaí. Choimeád an Fairceallach siar ó na Fianna a fhad a bhíodar ag fiach ach tháinig sé suas chucu san oíche nuair a chuadar chun suain. Nach minic a thagann imeachtaí an lae isteach inár n-intinn nuair a théimid féin chun suain.',
+    en: 'Ceann de na scéaltacha móráltachta i measc na Scéalta Fiannachta é seo. Chuirfeadh sé fabhalscéalta Aesop i gcuimhne duit. Níl aon chaint ann ar an ngaiscíocht ná ar thréithe na Féinne. Léiriú atá anseo ar na ceisteanna móra a bhíonn os comhair an uile dhuine. Ní féidir leat éalú uait féin. Bíonn do choinsias nó do dhia ag faire ort i gcónaí cé go gcoimeádann sé/sí siar uait a fhad a bhíonn tú i mbun do chuid cúramaí. Choimeád an Fairceallach siar ó na Fianna a fhad a bhíodar ag fiach ach tháinig sé suas chucu san oíche nuair a chuadar chun suain. Nach minic a thagann imeachtaí an lae isteach inár n-intinn nuair a théimid féin chun suain.'
+  },
+  fairceallach2: {
+    ga: 'Thug an Fairceallach cuireadh chun féasta d’Fhionn agus do na Fianna ar fad. Ag doras an árais ina rabhadar chun an féasta a chaitheamh bhí an bhean ba dheise dar leag aon duine beo súil uirthi riamh. Shantaigh gach duine acu ina diaidh. Siombal den óige a bhí inti agus bhí na seanfhir tar éis í a chaitheamh uatha i ngan fhios dóibh féin. Bhí sí ag na fir óga cé nár aithin siad í.',
+    en: 'Thug an Fairceallach cuireadh chun féasta d’Fhionn agus do na Fianna ar fad. Ag doras an árais ina rabhadar chun an féasta a chaitheamh bhí an bhean ba dheise dar leag aon duine beo súil uirthi riamh. Shantaigh gach duine acu ina diaidh. Siombal den óige a bhí inti agus bhí na seanfhir tar éis í a chaitheamh uatha i ngan fhios dóibh féin. Bhí sí ag na fir óga cé nár aithin siad í.'
+  },
+  fairceallach3: {
+    ga: ' Cuireadh togha gach bia agus rogha gach dí os a gcomhair ach a luaithe is a chas an Fairceallach a dhroim leo, léim sé ghadhar a bhí ina luí cois tine in airde ar na boird agus d’ailp siad a raibh ann. Bhí leisce ar Fhionn a admháil gurbh iad na gadhair a thóg an bia. Siombal den tsaint a bhí iontu, saint a thagann romhainn go minic. Shocraigh an sean-duine liath an scéal nuair a d’fhéach sé ar na gadhair agus chuir sé chun báis iad. Siombal den mbás ba ea an sean duine liath. Ní raibh aon leigheas ar an saint ach an bás. Níor bhain na Fianna an sásamh as ar cuireadh rompu go dtí go raibh an tsaint imithe uatha.',
+    en: ' Cuireadh togha gach bia agus rogha gach dí os a gcomhair ach a luaithe is a chas an Fairceallach a dhroim leo, léim sé ghadhar a bhí ina luí cois tine in airde ar na boird agus d’ailp siad a raibh ann. Bhí leisce ar Fhionn a admháil gurbh iad na gadhair a thóg an bia. Siombal den tsaint a bhí iontu, saint a thagann romhainn go minic. Shocraigh an sean-duine liath an scéal nuair a d’fhéach sé ar na gadhair agus chuir sé chun báis iad. Siombal den mbás ba ea an sean duine liath. Ní raibh aon leigheas ar an saint ach an bás. Níor bhain na Fianna an sásamh as ar cuireadh rompu go dtí go raibh an tsaint imithe uatha.'
+  },
+  posadh_ar_an_mblascaod_mor1: {
+    ga: 'Seo giota as scéal a scríobh Máire Ní Ghuithín, bean a chaith cuid mhaith dá saol ar an mBlascaod sular aistrigh sí go Dún Chaoin. Bhí pobal beo bríomhar ar an mBlascaod go dtí gur tréigeadh an t-oileán sa bhliain 1953. Bhí daoine ar leith ar an oileán agus cultúr ar leith acu ar an oileán cé go raibh ceangal láidir acu le Dún Chaoin - an chuid sin den míntír ba giorra dóibh. Bhí nósanna dá gcuid féin acu agus a slí féin chun dul i ngleic le saol an oileáin.',
+    en: 'Seo giota as scéal a scríobh Máire Ní Ghuithín, bean a chaith cuid mhaith dá saol ar an mBlascaod sular aistrigh sí go Dún Chaoin. Bhí pobal beo bríomhar ar an mBlascaod go dtí gur tréigeadh an t-oileán sa bhliain 1953. Bhí daoine ar leith ar an oileán agus cultúr ar leith acu ar an oileán cé go raibh ceangal láidir acu le Dún Chaoin - an chuid sin den míntír ba giorra dóibh. Bhí nósanna dá gcuid féin acu agus a slí féin chun dul i ngleic le saol an oileáin.'
+  },
+  posadh_ar_an_mblascaod_mor2: {
+    ga: 'Sa ghiota seo tugtar cur síos dúinn ar bhainiseacha agus mar a phóstaí na daoine an uair sin. Is trí cheamhnais is mó a thagadh daoine le chéile. Is i dteach an fhir is mó a chónaíodh an lánúin nua-phósta. Dá dtarlódh sé gur bhog an fear isteach i dteach na mná ‘cliamhain isteach’ a thabharfaí air. Ba leasc leis na seanfhir a bheith gan clann mac chun a ngabhaltais a fhágáil acu. Chónaíodh trí ghlúin faoin díon céanna agus, ar ndóigh, bhí na tithe an-bheag i gcomparáid le tithe an lae inniu.',
+    en: 'Sa ghiota seo tugtar cur síos dúinn ar bhainiseacha agus mar a phóstaí na daoine an uair sin. Is trí cheamhnais is mó a thagadh daoine le chéile. Is i dteach an fhir is mó a chónaíodh an lánúin nua-phósta. Dá dtarlódh sé gur bhog an fear isteach i dteach na mná ‘cliamhain isteach’ a thabharfaí air. Ba leasc leis na seanfhir a bheith gan clann mac chun a ngabhaltais a fhágáil acu. Chónaíodh trí ghlúin faoin díon céanna agus, ar ndóigh, bhí na tithe an-bheag i gcomparáid le tithe an lae inniu.'
+  },
+  oisin_i_dTir_na_nOg1: {
+    ga: 'Seo ceann de na scéalta Fiannaíochta. Dream saighdiúirí ab ea na Fianna a raibh sé de chúram orthu Éire a chosaint ar a naimhde. Mhair siad faoin spéir ó Bhealtaine go Samhain agus fuair siad a gcuid bia trí sheilg. Thaitin an bradán agus an fia leo, ach go háirithe. Ba é Fionn Mac Cumhaill a bhí i gceannas ar na Fianna agus bhí ómós ag gach ball dó. Ní raibh ins na Fianna ach laochra, gach aon duine acu, agus iad ábalta gaiscí ósnádúrtha a dhéanamh.',
+    en: 'Seo ceann de na scéalta Fiannaíochta. Dream saighdiúirí ab ea na Fianna a raibh sé de chúram orthu Éire a chosaint ar a naimhde. Mhair siad faoin spéir ó Bhealtaine go Samhain agus fuair siad a gcuid bia trí sheilg. Thaitin an bradán agus an fia leo, ach go háirithe. Ba é Fionn Mac Cumhaill a bhí i gceannas ar na Fianna agus bhí ómós ag gach ball dó. Ní raibh ins na Fianna ach laochra, gach aon duine acu, agus iad ábalta gaiscí ósnádúrtha a dhéanamh.'
+  },
+  oisin_i_dTir_na_nOg2: {
+    ga: 'Tá an scéal seo bunaithe ar eachtraí Oisín, mac Fhinn, agus ar a shaol i dTír na nÓg agus mar a d’fhill sé ar Éirinn tar éis cúpla céad bliain. Faoin am gur tháinig sé ar ais bhí Fionn agus na Fianna imithe as a saol. Bhí sé ar mhuin capaill agus dúradh leis gan a chos a leagan ar thalamh na hÉireann nó go n-iompódh sé isteach ina sheanfhear críonna caite agus nach bhfillfeadh sé ar Thír na nÓg go brách arís. Gheall sé go ndéanfadh sé amhlaidh. Ní mar a shíltear a bhítear, áfach, agus thit sé dá chapall agus rinneadh seanfhear de. Cuireadh i láthair Naomh Pádraig é agus rinne an naomh a dhícheall é a bhaiste chun go mbeadh sé ina Chríostaí.',
+    en: 'Tá an scéal seo bunaithe ar eachtraí Oisín, mac Fhinn, agus ar a shaol i dTír na nÓg agus mar a d’fhill sé ar Éirinn tar éis cúpla céad bliain. Faoin am gur tháinig sé ar ais bhí Fionn agus na Fianna imithe as a saol. Bhí sé ar mhuin capaill agus dúradh leis gan a chos a leagan ar thalamh na hÉireann nó go n-iompódh sé isteach ina sheanfhear críonna caite agus nach bhfillfeadh sé ar Thír na nÓg go brách arís. Gheall sé go ndéanfadh sé amhlaidh. Ní mar a shíltear a bhítear, áfach, agus thit sé dá chapall agus rinneadh seanfhear de. Cuireadh i láthair Naomh Pádraig é agus rinne an naomh a dhícheall é a bhaiste chun go mbeadh sé ina Chríostaí.'
+  },
+  oisin_i_dTir_na_nOg3: {
+    ga: 'Seo scéal Oisín agus é ina sheanfhear chríonna chaite',
+    en: 'Seo scéal Oisín agus é ina sheanfhear chríonna chaite'
+  },
+  dis1: {
+    ga: 'Seo scéal faoi lánúin atá pósta agus ina gcónaí i dteach ar imeall na cathrach. Bíonn an fear céile, Seán, ag obair i rith an lae agus is breá leis teacht abhaile agus a pháipéar nuachta a léamh ar a shuaimhneas. Tá a bhean chéile tinn tuirseach den saol atá aici sa bhaile is gan aon chomhluadar aici.',
+    en: 'Seo scéal faoi lánúin atá pósta agus ina gcónaí i dteach ar imeall na cathrach. Bíonn an fear céile, Seán, ag obair i rith an lae agus is breá leis teacht abhaile agus a pháipéar nuachta a léamh ar a shuaimhneas. Tá a bhean chéile tinn tuirseach den saol atá aici sa bhaile is gan aon chomhluadar aici.'
+  },
+  dis2: {
+    ga: 'Nuair a thagann bean eile timpeall chun suirbhé a dhéanamh, tapaíonn sí an deis agus insíonn sí a scéal di. Is cosúil gur chuir sí leis an scéal go mór. Baineadh siar as Seán nuair a chuala sé faoin méid a bhí ráite ag a bhean. Ní hamháin sin, ach bhí sí chun dul ag obair mar ionadaí do bhean an tsuirbhé fad a bheadh sise ar shaoire mháithreachais. Ní mó ná sásta a bhí Seán, ach bhí casadh sa scéal agus léigh leat go bhfeice tú!',
+    en: 'Nuair a thagann bean eile timpeall chun suirbhé a dhéanamh, tapaíonn sí an deis agus insíonn sí a scéal di. Is cosúil gur chuir sí leis an scéal go mór. Baineadh siar as Seán nuair a chuala sé faoin méid a bhí ráite ag a bhean. Ní hamháin sin, ach bhí sí chun dul ag obair mar ionadaí do bhean an tsuirbhé fad a bheadh sise ar shaoire mháithreachais. Ní mó ná sásta a bhí Seán, ach bhí casadh sa scéal agus léigh leat go bhfeice tú!'
+  },
+  an_gnathrud: {
+    ga: 'Tá an scéal seo suite i mBéal Feirste le linn na dtrioblóidí. Tá cur síos ann ar ghnáthfhear oibre agus é i mbun a ghnáthshaoil, gnáthoíche Dé hAoine. Ba ghnách leis dul isteach i gcomhair cúpla deoch lena chuid comrádaithe oíche Dé hAoine tar éis a gcuid oibre. Is léir nach scéal seicteach é seo mar Jimmy atá ar an bpríomhcharachtar agus Billy a bhí ar dhuine dá chairde. Thabharfadh sé seo le fios go raibh na Caitlicigh agus na Protastúnaigh ag meascadh le chéile go sóisialta. Ní fear mór óil a bhí in Jimmy ach bhíodh an nós aige cúpla deoch a ól lena chomrádaithe sula raibh páistí acu. Ní ligfeadh a bhean chéile, Sarah, dó éirí as an nós ar eagla go gceapfadh daoine go raibh sé smachtaithe agus ceannsaithe aici. Ba oibrí dian, dícheallach é agus rinne sé ard-obair chun a theach a dhéanamh suas gach oíche tar éis a ghnáthlá oibre. Ba í a bhean chéile a rinne baile den teach trí chuirtíní agus troscán a chur i gcóir. Bhí Jimmy ag tnúth go mór le dul abhaile. Fuair sé bia Síneach ar an slí, ach faraor níor shroich sé an baile riamh. Gnáthrud ag an am.',
+    en: 'Tá an scéal seo suite i mBéal Feirste le linn na dtrioblóidí. Tá cur síos ann ar ghnáthfhear oibre agus é i mbun a ghnáthshaoil, gnáthoíche Dé hAoine. Ba ghnách leis dul isteach i gcomhair cúpla deoch lena chuid comrádaithe oíche Dé hAoine tar éis a gcuid oibre. Is léir nach scéal seicteach é seo mar Jimmy atá ar an bpríomhcharachtar agus Billy a bhí ar dhuine dá chairde. Thabharfadh sé seo le fios go raibh na Caitlicigh agus na Protastúnaigh ag meascadh le chéile go sóisialta. Ní fear mór óil a bhí in Jimmy ach bhíodh an nós aige cúpla deoch a ól lena chomrádaithe sula raibh páistí acu. Ní ligfeadh a bhean chéile, Sarah, dó éirí as an nós ar eagla go gceapfadh daoine go raibh sé smachtaithe agus ceannsaithe aici. Ba oibrí dian, dícheallach é agus rinne sé ard-obair chun a theach a dhéanamh suas gach oíche tar éis a ghnáthlá oibre. Ba í a bhean chéile a rinne baile den teach trí chuirtíní agus troscán a chur i gcóir. Bhí Jimmy ag tnúth go mór le dul abhaile. Fuair sé bia Síneach ar an slí, ach faraor níor shroich sé an baile riamh. Gnáthrud ag an am.'
+  },
+  hurlamboc: {
+    ga: 'Scéal grinn é seo agus é scríofa mar aor ar an saol meánaicmeach a fhaightear i mbruachbhaile ardnósach. Chuirfeadh sé ‘keeping up appearances’ i gcuimhne duit. Tá an scéal scríofa i bhfoirm chomhrá idir Lisín agus a clann. Bean mhórchúiseach is ea bean an tí, Lisín. Bíonn sí ag iarraidh smacht a choimeád ar a teach, ar a clann agus ar a fear. Tá a fear céile tar éis airgead mór a shaothrú ach braitheann sí gurb í féin a bhí taobh thiar do gach rud a rinne sé. Tá siad chun cóisir mhór a bheith acu mar chomóradh ar a bpósadh agus bhí sí ag iarraidh go mbeadh a cóisir siúd níos fearr agus níos ardnósaí ná aon chóisir eile a bhí sa cheantar riamh. Níl post aici féin ach cuireann sí spéis san oiread sin rudaí difriúla gur deacair a saol a shamhlú nó a chreidiúint go bhféadfadh sí an oiread sin rudaí éagsúla a dhéanamh. Is léir gur saol bréagach atá aici agus gur scigmhagadh ar an saol ardnósach atá sa phíosa.',
+    en: 'Scéal grinn é seo agus é scríofa mar aor ar an saol meánaicmeach a fhaightear i mbruachbhaile ardnósach. Chuirfeadh sé ‘keeping up appearances’ i gcuimhne duit. Tá an scéal scríofa i bhfoirm chomhrá idir Lisín agus a clann. Bean mhórchúiseach is ea bean an tí, Lisín. Bíonn sí ag iarraidh smacht a choimeád ar a teach, ar a clann agus ar a fear. Tá a fear céile tar éis airgead mór a shaothrú ach braitheann sí gurb í féin a bhí taobh thiar do gach rud a rinne sé. Tá siad chun cóisir mhór a bheith acu mar chomóradh ar a bpósadh agus bhí sí ag iarraidh go mbeadh a cóisir siúd níos fearr agus níos ardnósaí ná aon chóisir eile a bhí sa cheantar riamh. Níl post aici féin ach cuireann sí spéis san oiread sin rudaí difriúla gur deacair a saol a shamhlú nó a chreidiúint go bhféadfadh sí an oiread sin rudaí éagsúla a dhéanamh. Is léir gur saol bréagach atá aici agus gur scigmhagadh ar an saol ardnósach atá sa phíosa.'
+  },
+  seal_i_neipeal: {
+    ga: 'Seo cur síos ar eachra a tharla le linn don údar cuairt a thabhairt ar Neipeal. Bhí sé ag cur faoi oíche in óstán de shaghas nuair a tháinig fear chuige a bhrú caint air. Ba fhear fiosrach é, agus bhí sé ag iarraidh gach eolas faoin spéir a fháil amach faoin údar. B’fhear mór gnó a bhí ann, a mhaígh sé. Bhí sé an-saibhir agus go leor comhlachtaí éagsúla faoina chúram. Ní raibh aon airgead aige ina phóca, áfach, agus b’éigean don údar cúpla deoch a cheannach dó. Lean sé leis ag iarraidh bob a bhualadh ar an údar agus ag tathant air airgead mór a infheistiú i gceann dá chuid comhlachtaí. Chuir muintear an tí in iúl dó gur cneámhaire a bhí i mo dhuine agus nach raibh uaidh ach airgead a fháil. Lean an t-údar leis agus é ag ligint air féin gur chreid sé gach focal a tháinig amach as a bhéal. Faoi dheireadh na hoíche rinne sé “infheistíocht mhór” agus cheap an cneámhaire nach raibh lá mór aige go dtí sin. D’íoc sé é le mol mór airgid ach níor thuig mo dhuine nach raibh aon luach gur fiú caint air leis na billí airgid. Lira na hIodáile a bhí iontu. Nach air a bheadh an díomá nuair a gheobhadh sé amach agus é sa bhanc in Kathmandu nárbh fhiú faic a stóras.',
+    en: 'Seo cur síos ar eachra a tharla le linn don údar cuairt a thabhairt ar Neipeal. Bhí sé ag cur faoi oíche in óstán de shaghas nuair a tháinig fear chuige a bhrú caint air. Ba fhear fiosrach é, agus bhí sé ag iarraidh gach eolas faoin spéir a fháil amach faoin údar. B’fhear mór gnó a bhí ann, a mhaígh sé. Bhí sé an-saibhir agus go leor comhlachtaí éagsúla faoina chúram. Ní raibh aon airgead aige ina phóca, áfach, agus b’éigean don údar cúpla deoch a cheannach dó. Lean sé leis ag iarraidh bob a bhualadh ar an údar agus ag tathant air airgead mór a infheistiú i gceann dá chuid comhlachtaí. Chuir muintear an tí in iúl dó gur cneámhaire a bhí i mo dhuine agus nach raibh uaidh ach airgead a fháil. Lean an t-údar leis agus é ag ligint air féin gur chreid sé gach focal a tháinig amach as a bhéal. Faoi dheireadh na hoíche rinne sé “infheistíocht mhór” agus cheap an cneámhaire nach raibh lá mór aige go dtí sin. D’íoc sé é le mol mór airgid ach níor thuig mo dhuine nach raibh aon luach gur fiú caint air leis na billí airgid. Lira na hIodáile a bhí iontu. Nach air a bheadh an díomá nuair a gheobhadh sé amach agus é sa bhanc in Kathmandu nárbh fhiú faic a stóras.'
+  },
+  LARA_title: {
+    ga: 'LARA: Cúntóir Foghlama agus Léitheoireachta: <br> Ardán Oscailte chun Téacsanna Labhartha atá Áisiúil do Léitheoir a Chruthú ar Líne',
+    en: 'LARA: a Learning And Reading Assistant <br> An Open Platform for Creating Reader-Friendly Online Language Speech-enabled Texts'
+  },
+  LARA_for_Irish_title: { ga: 'LARA don Ghaeilge', en: 'LARA for Irish' },
+  LARA_for_Irish: {
+    ga: '<b>An Scéalaí – LARA.</b> Is cur chuige comhtháite é chun an Ghaeilge a fhoghlaim. Tionscnamh taighde is ea é seo a chuirfidh ábhar éisteachta agus ábhar léitheoireachta atá taitneamhach ar fáil trí úsaid a bhaint as an teicneolaíocht is nua-aimseartha atá forbartha don Ghaeilge i réimse na teanga is na hurlabhra.',
+    en: '<b>An Scéalaí–LARA</b> is an integrated approach to learning Irish. It is a research project designed to make reading and listening to stories in Irish accessible and enjoyable, by harnessing the latest speech and language technologies available for Irish. '
+  },
+  what_is_LARA_point1: {
+    ga: 'Cúntóir Foghlama agus Léitheoireachta (‘<b>L</b>earning <b>a</b>nd <b>R</b>eading <b>A</b>ssistant’)',
+    en: '‘<b>L</b>earning <b>a</b>nd <b>R</b>eading <b>A</b>ssistant’'
+  },
+  what_is_LARA_point2: {
+    ga: 'Comhshaothar atá ann leis an tionscadal <a href="https://www.unige.ch/callector/" target="_blank" rel="noopener noreferrer"> CALLECTOR</a>, atá bunaithe in Ollscoil na Ginéive',
+    en: 'A collaboration with the <a href="https://www.unige.ch/callector/" target="_blank" rel="noopener noreferrer"> CALLECTOR</a> project, based in the University of Geneva'
+  },
+  what_is_LARA_point3: {
+    ga: 'Is í an aidhm atá ann le LARA ná: <ul><li> áiseanna a chur ar fáil ar líne chun tacú le foghlaim teangacha tríd an léitheoireacht agus an éisteacht agus</li><li> téacsanna a dhéanamh níos intuigthe chun cabhrú le foghlaimeoirí forbairt a dhéanamh ar a gcuid léitheoireachta, a stór focal agus a gcumas fuaimnithe</li></ul>',
+    en: 'The goal with LARA is to: <ul><li> provide online resource to support language learning through reading and listening </li><li> to makes texts more comprehensible to help learners develop their reading, vocabulary and pronunciation skills</li></ul> '
+  },
+  what_is_LARA_body1: {
+    ga: 'Trí úsáid a bhaint as LARA is féidir gnáth-théacs i nGaeilge a chasadh isteach ina ábhar ilmheáin idirghníomhach chun tacú le forbairt scileanna teanga tríd an léitheoireacht.',
+    en: 'Using LARA, one can convert plain texts in Irish into an interactive multimedia form designed to support development of L2 language skills by reading.'
+  },
+  what_is_LARA_body2: {
+    ga: 'Ceann de na gnéithe is suntasaí atá ag LARA chomh fada is a bhaineann sé leis an nGaeilge ná an comhcheangal a dhéanann sé idir guthanna sintéiseacha ABAIR agus téacs scríofa. Cuireann na guthanna seo eiseamláirí de chaint nádúrtha ar fáil, rud a chabhróidh leis an bhfoghlaimeoir comhcheangal a dhéanamh idir an focal scríofa agus an fhuaim a théann leis. An aidhm atá ann ná timpeallacht a chruthú ina mbeidh an chaint ina dlúthchuid de cheachtanna léitheoireachta agus go mbeidh fuaimeanna dúchasacha ar fáil do na foghlaimeoirí chun cabhrú leo cleachtadh a dhéanamh ar na fuaimeanna seo.',
+    en: 'A major feature of LARA for Irish is the integration of the ABAIR synthetic voices for spoken output. These voices provide native speaker models of the language and incorporating them in the platform will help learners link the sounds of Irish to the written forms. The aim is to create an environment where speech is integral to reading activities, where learners are exposed to the native spoken language and developing native speaker pronunciation as a norm.'
+  },
+  what_is_LARA_body3: {
+    ga: 'Chomh fada agus a bhaineann sé leis an bhfoghlaimeoir, nuair a chuirtear an teanga labhartha leis an ábhar léitheoireachta nasctar an fhuaimniú leis an bhfoirm scríofa agus ba cheart go gcabhródh sé seo go mór greim a fháil go fo-chomhfhiosach ar phatrúin fhoghraíochta na teanga scríofa – rud atá riachtanach d’fhoghlaim na léitheoireachta.',
+    en: 'For learners, the prevalent use of speech output in reading materials means that the linkage of pronunciation and written forms is being reinforced while reading, and this should greatly assist learners to gain an intuitive grasp of the phonic regularities of the written language - crucial to literacy acquisition.'
+  },
+  for_whom: { ga: 'Cé dó?', en: 'For Whom?' },
+  for_learners: {
+    ga: '<i><b>D’fhoghlaimeoirí</b></i> : beidh fáil ar scéalta de réir mar is áisiúil don fhoghlaimeoir féin.',
+    en: '<i><b>For Learners</b></i> : stories are available for learners to browse in their own time.'
+  },
+  for_teachers: {
+    ga: '<i><b>Do mhúinteoirí</b></i> : is féidir le múinteoirí na scéalta a úsáid mar spreagadh chun:',
+    en: '<i><b>For Teachers</b></i> : teachers can use these stories as a springboard, for example to:'
+  },
+  for_teachers_point1: { ga: 'díospóireacht ranga a thosú', en: 'promote class discussion' },
+  for_teachers_point2: {
+    ga: 'an ceangal idir an focal labhartha agus an focal scríofa a dhaingniú',
+    en: 'reinforce the linkages between the written and spoken word (spelling and sound)'
+  },
+  for_teachers_point3: { ga: 'pointí gramadaí a léiriú', en: 'reinforce grammar points' },
+  for_teachers_point4: {
+    ga: 'teacht ar fhoinsí breise cluastuisceana',
+    en: 'act as a source for listening comprehension'
+  },
+  for_teachers_point5: {
+    ga: 'díospóireachtaí agus scríobh a spreagadh',
+    en: 'act a stimulus for debate and writing'
+  },
+  for_teachers_point6: {
+    ga: 'foghlaim fhéin-rialaithe a chothú',
+    en: 'act as a means of promoting self-directed learning'
+  },
+  for_whom_body: {
+    ga: '<i><b>Pobal ar Líne</b>: bí inár dteannta chun a bheith i do chruthaitheoir ábhair!</i> Táimid ag tabhairt cuiridh do dhaoine a ngearrscéalta féin a chur isteach (maraon le taifeadadh labhartha). Ar an mbonn seo is féidir linn banc ábhar a chruthú agus a roinnt. Foilseofar d’ainm agus do scoil le do scéal más maith leat agus beidh sé ar fáil ón shuíomh An Scéalaí-LARA!',
+    en: '<i><b>Online community</b>: join us and become the content creators!</i>  We invite people to contribute their own short stories (with audio recordings). In this way we can start to build a bank of shared resources. Your name and affiliation/school will be published with your story and listed on the An Scéalaí-LARA webpage!'
+  },
+  list_of_stories: {
+    ga: 'Scéalta atá ar fáil go dtí seo: ',
+    en: 'List of Stories Available to date:'
+  },
+  LARA_features_and_functionality: {
+    ga: 'Gnéithe agus Feidhmeanna LARA',
+    en: 'LARA features and functionality'
+  },
+  LARA_texts_include: { ga: 'I measc théacsanna LARA tá:', en: 'LARA texts include:' },
+  LARA_features1_point1: {
+    ga: 'an fhuaimniú a théann le gach focal agus abairt (guthanna sintéiseacha <i>ABAIR.ie</i>)',
+    en: 'audio (ABAIR synthetic voices) attached to words and sentences'
+  },
+  LARA_features1_point2: { ga: 'aistriúcháin', en: 'translations' },
+  LARA_features1_point3: {
+    ga: 'comhchordacht do gach scéal',
+    en: 'a concordance for each story'
+  },
+  LARA_features1_point4: {
+    ga: 'an mhinicíocht atá ag gach focal atá sna scéalta',
+    en: 'frequency lists for each word in each story'
+  },
+  LARA_features1_point5: {
+    ga: 'trí chliceáil ar fhocal is féidir leis an bhfoghlaimeoir na ceisteanna seo a leanas a fhreagairt:',
+    en: 'by clicking or hovering over a word the learner can answer:'
+  },
+  LARA_features1_point5_points: {
+    ga: '<li><i>conas a deirtear an focal?  </i>(le guthanna sintéiseacha ABAIR á léamh)</li><li><i>cén Béarla atá ar an bhfocal?  </i>(nasc le foclóir)</li><li><i>cá bhfaca tú an focal seo cheana?  </i>(taispeántar liosta de gach comhthéacs ina raibh an focal sa scéal – más briathar atá ann, ‘faigh’, mar shampla, cuirfear gach leagan de, ‘fuair’, ‘fáil’, ‘gheobhaidh’, agus mar sin de ar fáil)</li>',
+    en: '<li><i>what does it sound like?  </i>(listen to one of the ABAIR synthetic voices reading aloud the word and/or sentence)</li><li><i>what is its translation?  </i>(links to popup translation of every word)</li><li><i>where have I seen it before?  </i>(opens a list where it shows every other time that word has been used – if it’s a verb, for example ‘faigh’ – you’ll see every instantiation ‘fuair’ / ‘fáil’ / ‘gheobhaidh’, etc.)</li>'
+  },
+  LARA_links_the_word: {
+    ga: 'Nascann LARA an focal scríofa leis an bhfocal labhartha:',
+    en: 'LARA links the spoken and written word:'
+  },
+  LARA_links_the_word_point1: {
+    ga: 'Tá difríocht an-mhór idir fuaimniú na Gaeilge agus fuaimniú an Bhéarla. Tá difríocht an-mhór idir consan caol agus consan leathan sa Ghaeilge, mar shampla. Is minic nach dtugtar aird air seo a bhuíochas don doiléireacht a théann le córas scríofa na Gaeilge agus is minic nach gcuirtear an ceangal idir an litriú agus an fhuaim ar a súile do na foghlaimeoirí. Trí a bheith ag éisteacht leis na scéalta agus tú ag leanúint an téacsa daingnítear an ceangal idir an fhuaimniú agus an leagan scríofa.',
+    en: 'The pronunciation of Irish is very different from English. A major feature of the sound system is the contrast of palatalised and velarised (broad and slender) consonants (with a very large inventory, relative to English). This feature is partially obscured by an opaque writing system, and the link of the sounds to written forms is frequently not highlighted for learners. By listening to stories while reading in LARA, the links between the pronunciation and written forms are constantly being reinforced.'
+  },
+  more_information: { ga: 'Tuilleadh Eolais', en: 'More Information' },
+  on_the_background_of_LARA: { ga: '…ar chúlra LARA:', en: '…on the background of LARA:' },
+  background_point1: {
+    ga: 'Tionscnamh foinse oscailte is ea é atá ar an bhfód ó 2018 (tuilleadh anseo: <a href="https://www.unige.ch/callector/lara/" target="_blank" rel="noopener noreferrer"> https://www.unige.ch/callector/lara/</a>)',
+    en: 'it’s collaborative open source project, active since mid-2018 (read more here: <a href="https://www.unige.ch/callector/lara/" target="_blank" rel="noopener noreferrer"> https://www.unige.ch/callector/lara/</a>)'
+  },
+  background_point2: {
+    ga: 'Tá dlúthcheangal aige le <a href="https://enetcollect.net" target="_blank" rel="noopener noreferrer">enetCollect</a>, gréasán Eorpach COST a nascann na céadta daoine gur spéis leo an réimse trasnaithe idir Foghlaim Ríomhchuiditen Teanga agus sluafhoinsiú (COST Action CA16105 – enetCollect : a European Network for Combining Language Learning with Crowdsourcing Techniques)',
+    en: 'There is a close connection to <a href="https://enetcollect.net" target="_blank" rel="noopener noreferrer">enetCollect</a>, a European COST network which links together several hundred people interested in the intersection of Computer-Assisted Language Learning and crowdsourcing (COST Action CA16105 – enetCollect : a European Network for Combining Language Learning with Crowdsourcing Techniques)'
+  },
+  on_the_research_background: { ga: '…ar an gcúlra taighde:', en: '…on the research background:' },
+  on_the_research_background_point1: {
+    ga: 'tá an cur chuige atá in úsáid i LARA nasctha le ‘Theory of Input’ de chuid Krashen (Krashen, 1982)– <i>"language learning proceeds most successfully when learners are presented with interesting and comprehensible L2 material in a low anxiety situation"</i>',
+    en: 'the approach taken within LARA is in line with Krashen’s Theory of Input (Krashen, 1982)– <i>"language learning proceeds most successfully when learners are presented with interesting and comprehensible L2 material in a low anxiety situation"</i>'
+  },
+  on_the_research_background_point2: {
+    ga: 'leanann sé uaidh seo go bhfuil <i>"reading and listening practice are important for L2 learning"</i> (Grabe and Stoller, 2012)',
+    en: 'it follows that <i>"reading and listening practice are important for L2 learning"</i> (Grabe and Stoller, 2012)'
+  },
+  on_the_research_background_point3: { ga: 'tuilleadh le teacht…', en: 'more to come...' },
+  on_the_speech_and_technology: {
+    ga: '…ar an teicneolaíocht urlabhra agus teanga atá taobh thiar do LARA don Ghaeilge:',
+    en: '…on the speech and language technology behind LARA for Irish:'
+  },
+  on_the_speech_and_technology_point1: {
+    ga: 'guthanna sintéiseacha ABAIR: fireann agus baineann sa trí mhórchanúint',
+    en: 'a range of ABAIR voices: male and female in all three major dialects '
+  },
+  on_the_speech_and_technology_point2: {
+    ga: 'inneall urlabhra ABAIR: tá na guthanna DNN in úsáid chun do na téacsanna Gaeilge <ul><li>tá teach tar an sintéiseoir seo ar <a href="https://www.abair.tcd.ie/" target="_blank" rel="noopener noreferrer">abair.ie</a>. Is féidir tuilleadh a léamh faoi thionscadal ABAIR ag (Ní Chasaide et al., 2017) agus ar na féidearthachtaí a bhaineann leis an tsintéis i gcomhthéacs FRT ag (Ní Chiaráin and Ní Chasaide, 2020).<ul><li>Ní mór a rá go mbíonn forbairt leanúnach ar siúl ar na guthanna sintéiseacha. Tá éisteacht phrofaí déanta ar scéalta LARA agus méid áirithe ceartúcháin déanta chun feabhas a chur ar chaighdeán an aschuir. </li></ul></li></ul>',
+    en: 'ABAIR speech engine: the DNN-based synthetic voices were used to produce the audio for the Irish texts <ul><li>the synthesiser is freely available online at <a href="https://www.abair.tcd.ie/" target="_blank" rel="noopener noreferrer">abair.ie</a>. For more on the ABAIR initiative see (Ní Chasaide et al., 2017) and on the potential of TTS in CALL see (Ní Chiaráin and Ní Chasaide, 2020).<ul><li>Note that since TTS will be in a continuous state of development, we have prooflistened to the LARA stories and made the necessary corrections to the automatically generated phonetic transcription to improve the quality of the speech output.</li></ul></li></ul>'
+  },
+  on_the_speech_and_technology_point3: {
+    ga: 'Irishfst is ea an leimeoir Gaeilge (Uí Dhonnchadha, 2010). Tá sé ar fáil ar líne ag <a href="https://www.scss.tcd.ie/~uidhonne/irish.utf8.htm" target="_blank" rel="noopener noreferrer"> https://www.scss.tcd.ie/~uidhonne/irish.utf8.htm</a> agus <a href="https://github.com/uidhonne/irishfst" target="_blank" rel="noopener noreferrer"> https://github.com/uidhonne/irishfst</a>',
+    en: 'the Irish lemmatizer used is Irishfst (Uí Dhonnchadha, 2010). It is available online <a href="https://www.scss.tcd.ie/~uidhonne/irish.utf8.htm" target="_blank" rel="noopener noreferrer"> https://www.scss.tcd.ie/~uidhonne/irish.utf8.htm</a> and in source code <a href="https://github.com/uidhonne/irishfst" target="_blank" rel="noopener noreferrer"> https://github.com/uidhonne/irishfst</a>'
+  },
+  sample_research_papers: { ga: '…Páipéirí Taighde - Samplaí', en: '…Sample Research Papers' },
+  lara_paper1: {
+    ga: 'Akhlaghi, E., Bédi, B., Butterweck, M., Chua, C., Gerlach, J., Habibi, H., Ikeda, J., Rayner, M., Sestigiani, S., and Zuckermann, G. (2019). Overview of LARA: A learning and reading assistant. In Proceedings of SLaTE 2019: 8th ISCA Workshop on Speech and Language Technology in Education, pages 99–103, 2019.',
+    en: 'Akhlaghi, E., Bédi, B., Butterweck, M., Chua, C., Gerlach, J., Habibi, H., Ikeda, J., Rayner, M., Sestigiani, S., and Zuckermann, G. (2019). Overview of LARA: A learning and reading assistant. In Proceedings of SLaTE 2019: 8th ISCA Workshop on Speech and Language Technology in Education, pages 99–103, 2019.'
+  },
+  lara_paper2: {
+    ga: 'Elham Akhlaghi, Branislav Bédi, Fatih Bektaş, Harald Berthelsen, Matthias Butterweck, Cathy Chua, Catia Cucchiarin, Gülşen Eryiğit, Johanna Gerlach, Hanieh Habibi, Neasa Ní Chiaráin, Manny Rayner, Steinþór Steingrímsson and Helmer Strik, Constructing multimodal language learner texts using LARA: experiences with nine languages, Proceedings of LREC 2020, <i>LREC 2020, Marseille, France, 11-16 May 2020.</i>',
+    en: 'Elham Akhlaghi, Branislav Bédi, Fatih Bektaş, Harald Berthelsen, Matthias Butterweck, Cathy Chua, Catia Cucchiarin, Gülşen Eryiğit, Johanna Gerlach, Hanieh Habibi, Neasa Ní Chiaráin, Manny Rayner, Steinþór Steingrímsson and Helmer Strik, Constructing multimodal language learner texts using LARA: experiences with nine languages, Proceedings of LREC 2020, <i>LREC 2020, Marseille, France, 11-16 May 2020.</i>'
+  },
+  the_abair_initiative: { ga: 'ABAIR:', en: 'The ABAIR Initiative:' },
+  abair_paper1: {
+    ga: 'Ní Chasaide, A., Ní Chiaráin, N., Wendler, C., Berthelsen, H., Murphy, A., and Gobl, C. (2017). The ABAIR initiative: Bringing spoken Irish into the digital space. In Proceedings of Interspeech 2017 , pages 2113 – 2117, Stockholm, Sweden.',
+    en: 'Ní Chasaide, A., Ní Chiaráin, N., Wendler, C., Berthelsen, H., Murphy, A., and Gobl, C. (2017). The ABAIR initiative: Bringing spoken Irish into the digital space. In Proceedings of Interspeech 2017 , pages 2113 – 2117, Stockholm, Sweden.'
+  },
+  abair_paper2: {
+    ga: 'Ní Chiaráin, N. and Ní Chasaide, A. (2020). The potential of text-to-speech synthesis in computer-assisted language learning: A minority language perspective. In Alberto Andujar, editor, Recent Tools for Computer- and Mobile-Assisted Foreign Language Learning , chapter 7, pages 149–169. IGI Global, Hershey, PA.',
+    en: 'Ní Chiaráin, N. and Ní Chasaide, A. (2020). The potential of text-to-speech synthesis in computer-assisted language learning: A minority language perspective. In Alberto Andujar, editor, Recent Tools for Computer- and Mobile-Assisted Foreign Language Learning , chapter 7, pages 149–169. IGI Global, Hershey, PA.'
+  },
+  other_relavent_research: { ga: 'Taighde ábhartha eile:', en: 'Other relevant research:' },
+  other_relavent_research1: {
+    ga: 'Grabe, W. and Stoller, F. L. (2012). Teaching reading. The Encyclopedia of Applied Linguistics.',
+    en: 'Grabe, W. and Stoller, F. L. (2012). Teaching reading. The Encyclopedia of Applied Linguistics.'
+  },
+  attends_secondary_school: {
+    ga: 'Táim ag freastal ar an meánscoil.',
+    en: 'I am currently attending secondary school.'
+  },
+  what_year_are_you_in: {
+    ga: 'Cén bhliain ina bhfuil tú?',
+    en: 'What school year are you in?'
+  },
+  listen_by: { ga: 'Éist leis', en: 'Listen by' },
+  paragraph: { ga: 'An t-alt ar fad ', en: 'Paragraph' },
+  sentence: { ga: 'Abairt ar abairt', en: 'Sentence' },
+  sponsors: { ga: 'Tacaíocht', en: 'Sponsors' },
+  sponsor_abair: {
+    ga: 'Tá an leagan seo de An Scéalaí á fhorbairt mar chuid den tionscadal <a href="http://www.abair.tcd.ie">ABAIR.ie</a>, á mhaoiniú ag an <a href="https://www.gov.ie/ga/eagraiocht/an-roinn-turasoireachta-cultuir-ealaion-gaeltachta-spoirt-agus-mean/"> Roinn Turasóireachta, Cultúir, Ealaíon, Gaeltachta, Spóirt agus Meán</a> agus páirt mhaoinithe ag an gCrannchur Náisiúnta. Is sa <a href="https://www.tcd.ie/slscs/clcs/psl/">tSaotharlann Foghraíochta agus Urlabhra</a>, i gColáiste na Tríonóide atá sé lonnaithe.',
+    en: 'This iteration of An Scéalaí is being developed as part of the <a href="http://www.abair.tcd.ie">ABAIR.ie initiative, funded by the <a href="https://www.gov.ie/en/organisation/department-of- tourism-culture-arts-gaeltacht-sport-and-media/">Department of Tourism, Culture, Arts, Gaeltacht, Sport and Media</a> and part-funded by the National Lottery. It is located in the <a href="https://www.tcd.ie/slscs/clcs/psl/">Phonetics and Speech Lab</a>.,Trinity College, Dublin.'
+  },
+  thanks_to: { ga: 'Ár mbuíochas le', en: 'We are grateful to:' },
+  sponsor_cogg: {
+    ga: '<a href="https://www.cogg.ie/">COGG</a> as maoiniú don tionscadal "Corpas Cliste", a eascróidh as An Scéalaí. Seo tionscadal a chuirfidh lenár dtuiscint ar shealbhú na Gaeilge agus ar thionchar na teicneolaíochta sa phróiseas sin.',
+    en: '<a href="https://www.cogg.ie/">COGG</a> for funding the "<i>Corpas Cliste</i>" project, which will be developed from An Scéalaí. This project will contribute to our knowledge of Irish language acquisition and examine how technology may impact this process..'
+  },
+  like_to_highlight: {
+    ga: 'Ba mhaith linn ár mbuíochas a chur in iúl do',
+    en: 'We would like to thank'
+  },
+  sponsor_cgd: {
+    ga: '<a href="https://cgd.ie/">Coláiste Ghaoth Dobhair</a>, do na múinteoirí agus do na mic léinn uile, as a bheith páirteach i staidéar píolótach ar scála mór i rith na bliana 2021. Tá an t-aiseolas atá faighte ag cur go mór leis an gcéad leagan eile de An Scéalaí.',
+    en: '<a href="https://cgd.ie/">Coláiste Ghaoth Dobhair</a>, its teachers and students, who took part in a large-scale pilot study during 2021. This study provided invaluable feedback which crucially informs the next stage of development.'
+  },
+  interested_teachers: {
+    ga: '*Ba mhaith linn teagmháil a dhéanamh le múinteoirí dara leibhéal a mbeadh suim acu An Scéalaí á úsáid le grúpaí sa Scoilbhliain 2021/22. Gach eolas ó Neasa Ní Chiaráin - neasa.nichiarain@tcd.ie.',
+    en: '*We are interested in forming focus groups among second level teachers who would like to use An Scéalaí with their classes during the 2021/22 school year. Please contact Neasa Ní Chiaráin – neasa.nichiarain@tcd.ie if you would like to participate.'
+  },
+  testimonials: { ga: 'Teistiméireachtaí', en: 'Testimonials' },
+  testimonial_1: {
+    ga: 'Sílim gurb é An Scéalaí an rud is áisiúla a chonaic mé ó thaobh foghlaim teangacha de riamh i mo shaol',
+    en: 'Sílim gurb é An Scéalaí an rud is áisiúla a chonaic mé ó thaobh foghlaim teangacha de riamh i mo shaol'
+  },
+  testimonial_2: {
+    ga: 'Ní raibh mé in ann a chreidiúint cé chomh tapa agus chomh cruinn a bhí an córas in ann botúin sa téacs a aithint. Bhí sé mar a bheadh múinteoir suite an sin ós mo chomhair amach ag cabhrú liom.',
+    en: 'Ní raibh mé in ann a chreidiúint cé chomh tapa agus chomh cruinn a bhí an córas in ann botúin sa téacs a aithint. Bhí sé mar a bheadh múinteoir suite an sin ós mo chomhair amach ag cabhrú liom.'
+  },
+  testimonial_3: {
+    ga: 'Chabhraigh sé go háirithe le mo chuid gramadaí, agus na botúin a dhéanaim go rialta (le mo litriú nó leis an tuiseal ginideach de ghnáth)',
+    en: 'Chabhraigh sé go háirithe le mo chuid gramadaí, agus na botúin a dhéanaim go rialta (le mo litriú nó leis an tuiseal ginideach de ghnáth)'
+  },
+  testimonial_4: {
+    ga: 'Tá An Scéalaí go hiontach chun feabhas a chur ar do chuid gramadaí. Chomh maith leis sin, is aoibhinn liom an rogha "seiceáil ó chluas". Is maith liom é a úsáid chun líofacht mo chuid abairtí a sheiceáil.',
+    en: 'Tá An Scéalaí go hiontach chun feabhas a chur ar do chuid gramadaí. Chomh maith leis sin, is aoibhinn liom an rogha "seiceáil ó chluas". Is maith liom é a úsáid chun líofacht mo chuid abairtí a sheiceáil.'
+  },
+  testimonial_5: {
+    ga: 'Ceapaim gur acmhainn iontach é An Scéalaí chun cabhrú le daoine nach bhfuil muinín acu scríobh as Gaeilge.',
+    en: 'Ceapaim gur acmhainn iontach é An Scéalaí chun cabhrú le daoine nach bhfuil muinín acu scríobh as Gaeilge.'
+  },
+  testimonial_6: {
+    ga: 'Is saghas tabhartas ó Dhia é An Scéalaí dom!',
+    en: 'Is saghas tabhartas ó Dhia é An Scéalaí dom!'
+  },
+  testimonial_7: {
+    ga: 'Ceapaim gur acmhainn dochreidte é LARA. Bhí leibhéal na Gaeilge deacair sa scéal, ach bhí sé éasca a thuiscint le LARA.',
+    en: 'Ceapaim gur acmhainn dochreidte é LARA. Bhí leibhéal na Gaeilge deacair sa scéal, ach bhí sé éasca a thuiscint le LARA.'
+  },
+  copyright: {
+    ga: 'Cóipcheart © 2021 An tSaotharlann Foghraíochta agus Urlabhra, Coláiste na Tríonóide, Baile Átha Cliath, Éire',
+    en: 'Copyright © 2021 Phonetics and Speech Laboratory, Trinity College, Dublin, Ireland'
+  },
+  from_students: {
+    ga: 'ó ghrúpa mac léinn 3ú leibhéal',
+    en: 'from a group of 3rd level students'
+  },
+  taidhgin_title: { ga: 'Taidhgín: Déan Comhrá', en: 'Taidhgín Bot' },
+  create_quiz_title: { ga: 'Cruthaigh do quiz féin', en: 'Create your own quiz' },
+  what_is_taidhgin_title: { ga: 'Cad é Taidhgín?', en: 'What is Taidhgín?' },
+  about_taidhgin1: {
+    ga: 'Is céile comhrá, nó ‘bat’ é Taidhgín. Scríobhann tú ceisteanna nó freagraí isteach. Aithníonn Taidhgín do chomhrá agus tugann sé freagra ar ais duit, ag brath ar an rud a scríobh tusa isteach. Tá Taidhgín ag brath ar intleacht shaorga, rud a chiallaíonn gur féidir leis pointí eolais a chruthú ón méid a scríobhann tusa isteach, agus é sin a úsáid chun leanúint leis an gcomhrá.',
+    en: '<i>Taidhgín</i> is a bot or conversation partner. You converse with him by writing questions or answers into the system . <i>Taidhgín</i> recognizes your input and responds accordingly. <i>Taidhgín</i> is based on artificial intelligence which enables it to take in text from the user and to use this to develop a conversation.'
+  },
+  about_taidhgin2: {
+    ga: 'Tugadh <i>Taidhgín</i> ar an gcóras seo mar gur féidir leis an duine daonna an méid a deir Taidhgín a thuiscint go héasca. Cé go dtógann <i>Taidhgín</i> eolas isteach, ní féidir leat a rá go ‘dtuigeann’ sé é mar a thuigeann daoine caint. Mar sin, ceapadh go raibh an sean-ráiteas a bhí sa Ghaeilge mar gheall ar a leithéid seo oirinach <i>“Tuigeann Tadhg Taidhgín, ach ní thuigeann Taidhgín tada”</i>.',
+    en: 'The system is called <i>Taidhgín</i> because humans can easily understand the output from the system or the speech from <i>Taidhgín</i>, but one cannot say that any digital system “understands” language in the way that a human can. Hence the Irish phrase <i>“Tuigeann Tadhg Taidhgín ach ní thuigeann Taidhgín tada”</i> seemed appropriate.'
+  },
+  about_taidhgin3: {
+    ga: 'Seo an chéad chéim i bhforbairt chórais chomhrá don Ghaeilge. Is í an chéad chéim eile a bheidh againn ná bait theagaisc, ag tosnú leis an mBat Mírialta, a chuirfidh ar chumas daltaí cleachtadh a dhéanamh ar bhriathra neamhrialta na Gaeilge. ‘Sé an coincheap atá taobh thiar den tionscadal seo ná banc acmhainní a fhásfaidh le hionchur uaibhse - na múinteoirí agus na daltaí a úsáidfidh an córas.',
+    en: 'This is the first phase in the development of a dialogue system for Irish. The next stage will see the development of a tutorial bot based on the irregular verbs. The concept for this project is a bank of resources that’ll grow over time with input from teachers and students.'
+  },
+  about_taidhgin4: {
+    ga: 'Beifear ag cur leis an gcóras de réir mar a thagann na teicneolaíochtaí teanga chun cinn – an aidhm atá againn ná go dtuigfidh Taidhgín caint na ndaoine agus go mbeidh sé ábalta comhrá a choimeád leo i nGaeilge bhreá nádúrtha.',
+    en: 'The system will be extended as the appropriate language technologies are developed – our longer term ambition is that <i>Taidhgín</i> will be able to understand the spoken language of the user and be able to converse using high quality native-like synthetic speech.'
+  },
+  how_to_tquiz: {
+    ga: 'Fáilte go ‘cruthaigh do quiz-bat’ féin ar leathanach <i>Thaidhgín</i>.<br><br>Bain úsáid as an leathanach seo chun do chuid quizeanna féin a chruthú agus a rith laistigh den bhat <i>‘Tadhgín’</i>.<br><br>Níl le déanamh agat ach ainm do quiz, do chuid ceisteanna agus do chuid freagraí a líonadh isteach agus beidh tú réidh le rocáil!!<br><br>Is féidir cur le líon na gceisteanna ag baint úsáide as an gcnaipe “Ceist nua” agus is féidir na freagraí ar fad a bheadh inghlactha a líonadh isteach ag baint úsáide as an gcnaipe “Cuir Freagraí”.<br><br>Nuair a bheidh deireadh déanta agat, cliceáil ar “Déanta” chun an quiz a shábháil. (Beidh sé de rogha agat freisin do quiz a íoslódáil mar chomhad .txt ar son do thaifead féin). Chomh luath is a bhíonn an quiz sábháilte agat is féidir é a roghnú agus é a rith ar leathanach <i>Taidhgín</i> faoi “Topaicí Pearsanta”.<br><br>Is féidir le múinteoirí quizeanna a chruthú le roinnt (a) lena ranganna féin agus (b) go poiblí.<br><br>Is féidir le daltaí quizeanna a chruthú freisin mar chleachtadh agus mar spraoi!',
+    en: "Welcome to the 'create your own quiz-bot' <i>Taidhgín</i> page.<br><br> Use this page to create your own quizzes which you can then run within the <i>Taidhgín</i> bot 💬. All you need to do is fill  in the name of your quiz, your questions, and your answers and you're good to go! You can add more questions with the 'Add Question' button, and you can add multiple acceptable answers with the 'Add Answer' button. <br><br>Once you have finished creating your quiz, click on 'Done' and then on 'yes' to save it. (You will also have the option to download the script as a .txt file for your own records). Once your quiz has been saved you can select it and run it on the <i>Taidhgín</i> page under 'Your Quizzes'. <br><br>Teachers can create quizzes and assign them to their class. There is also an option to share your quiz with the wider <i>An Scealaí</i> community. Students can create quizzes for practice and for fun 📖😄."
+  },
+  how_to_tquiz_title: { ga: 'Treoracha ℹ️', en: 'How to Use! ℹ️' },
+  quiz_done: { ga: 'Déanta', en: 'Done' },
+  quiz_add_q: { ga: 'Ceist eile', en: 'Add Question' },
+  quiz_add_a: { ga: 'Freagraí eile inghlactha', en: 'Add Answer' },
+  quiz_q_title: { ga: 'Ceisteanna', en: 'Questions' },
+  quiz_a_title: { ga: 'Freagraí', en: 'Answers' },
+  my_quiz_s: { ga: 'Na Quizeanna Agamsa', en: 'My Quizzes' },
+  taidhgin_about: { ga: 'Eolas', en: 'About' },
+  taidhgin_choose_dialect: { ga: 'Pioc do rogha canúna', en: 'Choose Dialect' },
+  taidhgin_audio_autoplay: { ga: 'Uathsheinn', en: 'Audio Autoplay' },
+  taidhgin_choose_topic: { ga: 'Roghnaigh Topaic', en: 'Choose a Topic' },
+  t_community_quiz: { ga: 'Quizeanna ón bPobal', en: 'Community Quizzes' },
+  t_insert_q: { ga: 'Scríobh ceist anseo', en: 'Write question here' },
+  t_insert_a: { ga: 'Scríobh freagra anseo', en: 'Write answer here' },
+  t_enterName: { ga: 'Ainm an Quiz', en: 'Name Quiz' },
+  taidhgin_currentDialect: { ga: 'Canúint: Corca Dhuibhne', en: 'Dialect: Kerry' },
+  taidhgin_my_quiz_title: { ga: 'Na Quizeanna Agamsa', en: 'My Quizzes' },
+  taidhgin_signup: {
+    ga: 'Cruthaigh cuntais leis An Scéalaí chun teacht ar quizeanna, chun do chuid quizeanna féin a chruthú agus a shábháil.',
+    en: 'Create an An Scéalaí account to access quizzes, and to create and save your own.'
+  },
+  my_teachquiz: { ga: 'Quizeanna mo Mhúinteora', en: "My Teacher's Quizzes" },
+  taidhgin_createThankMessage: {
+    ga: 'Go raibh maith agat as páirt a ghlacadh!😄',
+    en: "Thank you for using the 'make your own script' framwork! 😄"
+  },
+  save_script: { ga: 'Sábháil do quiz?', en: 'Save your quiz?' },
+  save_script_y: { ga: 'Sábháil ', en: 'Yes' },
+  save_script_n: { ga: 'Ná sábháil', en: 'No' },
+  taidhgin_saved_message: {
+    ga: 'Tá do quiz i dtaisce! Is féidir teacht air faoi ‘Na Quizeanna Agamsa’',
+    en: "Your script has been saved! You can now use it in Taidhgín under 'My Quizzes'."
+  },
+  taidhgin_askPublish: {
+    ga: 'Ar mhaith leat do quiz a chur ar fáil do phobal An Scéalaí?',
+    en: 'Would you like to publish your script to the An Scealaí community?'
+  },
+  t_downloadQuiz: { ga: 'Íoslódáil an quiz?', en: 'Download copy of your quiz?' },
+  fillAllEntries: { ga: 'Líon isteach gach bosca', en: 'Fill in all entries' },
+  publish_script_y: { ga: 'Ba mhaith', en: 'Yes' },
+  publish_script_n: { ga: 'Níor mhaith', en: 'No' },
+  closeSubmition: { ga: 'Dún', en: 'Close' },
+  go_to_taidhgin: { ga: 'Go dtí Taidhgín', en: 'Go to Taidhgín' },
+  delete_quiz: { ga: 'Scrios', en: 'Delete' },
+  open_quiz: { ga: 'Oscail', en: 'Open' },
+  tt_hts: { ga: 'inneall cainte 1', en: 'speech engine 1' },
+  tt_dnn: { ga: 'inneall cainte 2', en: 'speech engine 2' },
+  dnn_synthesiser: { ga: 'modh DNN', en: 'DNN synthesiser' },
+  go_to_fast_synthesiser: { ga: 'Bain triail as modh HTS', en: 'Try the HTS synthesiser' },
+  script_exists: {
+    ga: 'Tá an teideal seo in úsáid cheana',
+    en: 'Quiz with this name already exists'
+  },
+  taidhgin_verified_message: { ga: 'Faofar d’iontráil', en: 'Your quiz will be verified.' },
+  forgetQuizName: { ga: 'Gaeilge Version', en: "Don't forget to name your quiz." },
+  shuffle_questions: { ga: ' shuffle questions', en: ' shuffle questions' }
+}

--- a/ngapp/src/app/new_translation.ts
+++ b/ngapp/src/app/new_translation.ts
@@ -1,7 +1,7 @@
 export default {
   iso_code: { ga: 'ga', en: 'en' },
   vowels_should_agree: {
-    ga: 'Ba cheart go mbeadh na gutaí seo ar aon dul de réir riail Leathan / Caol.',
+    ga: 'Ba cheart go mbeadh na gutaí seo ar aon dul de réir riail Leathan/Caol.',
     en: 'These vowels should be in agreement according to the Leathan/Caol rule.'
   },
   name: { ga: 'Gaeilge', en: 'English' },

--- a/ngapp/src/app/translation.service.ts
+++ b/ngapp/src/app/translation.service.ts
@@ -4,6 +4,19 @@ import { AuthenticationService } from './authentication.service';
 import { HttpClient } from '@angular/common/http';
 import config from 'abairconfig';
 import { Observable } from 'rxjs';
+import new_trans from './new_translation';
+
+
+const new_translations = (()=>{
+  const ga = {};
+  const en = {};
+  for(const k of Object.keys(new_trans)) {
+    ga[k] = new_trans[k].ga;
+    en[k] = new_trans[k].en;
+  }
+  return {ga,en};
+})();
+
 
 export enum LANGUAGE {
   ENGLISH = 0,
@@ -32,7 +45,7 @@ export class TranslationService {
     }
   }
 
-  setLanguage(code: string) {
+  setLanguage(code: 'ga'|'en') {
     this.l = this.getLanguageFromCode(code);
 
     this.currentLanguage = (this.l.iso_code === 'en' ? LANGUAGE.ENGLISH : LANGUAGE.IRISH);
@@ -50,15 +63,10 @@ export class TranslationService {
     return (this.l.name === "English");
   }
 
-  getLanguageFromCode(code: string): object {
-    for (const language of translation.languages) {
-      if (language.iso_code === code) {
-        return language;
-      }
-    }
-    return null;
+  getLanguageFromCode(code: 'ga'|'en'): object {
+    return new_translations[code] ?? new_translations['ga'];
   }
-  
+
   getCurrentLanguage() : string {
     if(this.l) {
       return this.l.name;


### PR DESCRIPTION
I hope this PR will make editing/reviewing our translations easier.

Translations are now specified in `ngapp/src/app/new_translations.ts` in the form

```
.
.
.
  language: {
    ga: "Teanga",
    en: "Language",
  },
  vowels_should_agree: {
    ga: 'Ba cheart go mbeadh na gutaí seo ar aon dul de réir riail Leathan / Caol.',
    en: 'These vowels should be in agreement according to the Leathan/Caol rule.'
  },
.
.
.
```

