### PR TITLE
Only add '@' if there are mongo auth details are present

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "api",
       "version": "1.1.3",
       "license": "ISC",
       "dependencies": {

--- a/api/utils/dbUrl.js
+++ b/api/utils/dbUrl.js
@@ -1,8 +1,9 @@
 const config = require('../DB');
+
 // use the URL for the test DB if it has been set, otherwise use the normal DB.
 module.exports =
   process.env.TEST_MONGO_URL ||
   (process.env.DB_URL_PREFIX   || config.DB_URL_PREFIX   ) +
-  (process.env.DB_AUTH_DETAILS || config.DB_AUTH_DETAILS ) + '@' +
+  (process.env.DB_AUTH_DETAILS ? (process.env.DB_AUTH_DETAILS + '@') : config.DB_AUTH_DETAILS ) +
   (process.env.DB_HOSTNAME     || config.DB_HOSTNAME     ) +
   (process.env.DB              || config.DB              );


### PR DESCRIPTION
At the moment in `dbUrl.js` we have this line:

https://github.com/OisinNolan/An-Scealai/blob/e9ded099604ba442b1392b0ad691377c0ddf3a82/api/utils/dbUrl.js#L6

Adding the `'@'` is necessary when we need to provide login details for mongod (as in production) but not in development mode, where we typically don't have any login. This PR just changes that line to the following, checking whether or not there are local auth details before adding the `@`:
```
(process.env.DB_AUTH_DETAILS ? (process.env.DB_AUTH_DETAILS + '@') : config.DB_AUTH_DETAILS ) +
```