### PR TITLE
Teacher stats card fullscreen using mat dialog

### DIFF
--- a/ngapp/src/app/app.module.ts
+++ b/ngapp/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 import { RegisterModule } from 'register/register.module';
 import { AuthInterceptor } from 'app/interceptor/auth.interceptor';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 
 import { NgramDistributionModule } from 'app/story-stats/ngram-distribution/ngram-distribution.module';
 
@@ -154,6 +155,7 @@ import { StatsDashboardComponent } from './teacher-components/stats-dashboard/st
     MatNativeDateModule,
     MatFormFieldModule,
     MatSelectModule,
+    MatDialogModule,
     NgbModule,
     NgbDropdownModule,
     QuillModule.forRoot({
@@ -177,6 +179,7 @@ import { StatsDashboardComponent } from './teacher-components/stats-dashboard/st
     MatNativeDateModule,
     {provide : LocationStrategy , useClass: HashLocationStrategy },
     {provide : HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true},
+    {provide : MatDialogRef, useValue: {}},
   ],
   bootstrap: [
     AppComponent,

--- a/ngapp/src/app/story-stats/ngram-distribution/ngram-distribution/ngram-distribution.component.ts
+++ b/ngapp/src/app/story-stats/ngram-distribution/ngram-distribution/ngram-distribution.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
 import { Chart } from 'chart.js';
 
 import * as Wink from 'wink-nlp';
@@ -27,10 +28,13 @@ export class NgramDistributionComponent implements OnInit {
   selectedN: number = 1;
   ngramChart: Chart;
 
-  constructor() { }
+  constructor(
+    public dialogRef: MatDialogRef<NgramDistributionComponent>
+  ) { }
 
   ngOnInit(): void {
     this.loadNgramChart();
+    console.log('dialogref', this.dialogRef);
   }
 
   loadNgramChart() {

--- a/ngapp/src/app/story-stats/ngram-distribution/ngram-distribution/ngram-distribution.component.ts
+++ b/ngapp/src/app/story-stats/ngram-distribution/ngram-distribution/ngram-distribution.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import { Chart } from 'chart.js';
 
 import * as Wink from 'wink-nlp';
@@ -28,13 +27,10 @@ export class NgramDistributionComponent implements OnInit {
   selectedN: number = 1;
   ngramChart: Chart;
 
-  constructor(
-    public dialogRef: MatDialogRef<NgramDistributionComponent>
-  ) { }
+  constructor() { }
 
   ngOnInit(): void {
     this.loadNgramChart();
-    console.log('dialogref', this.dialogRef);
   }
 
   loadNgramChart() {

--- a/ngapp/src/app/teacher-components/stats-dashboard/stats-dashboard.component.html
+++ b/ngapp/src/app/teacher-components/stats-dashboard/stats-dashboard.component.html
@@ -1,11 +1,14 @@
-<div class="content">
+<div class="content" *ngIf="!dialogRef">
     <mat-card class="stats-card">
-        <mat-card-header class="stats-card-header">
-            <mat-card-title>N-gram Distribution</mat-card-title>
-            <i class="fa fa-expand" aria-hidden="true" (click)="toggleFullscreen($event)"></i>
-        </mat-card-header>
-        <mat-card-content>
-            <app-ngram-distribution [texts]="sampleTexts"></app-ngram-distribution>
-        </mat-card-content>
+        <ng-template #ngramTemplate [ngIf]="!dialogRef">
+            <mat-card-header class="stats-card-header">
+                <mat-card-title>N-gram Distribution</mat-card-title>
+                <i *ngIf="!dialogRef" class="fa fa-expand" aria-hidden="true" (click)="openModal(ngramTemplate)"></i>
+                <i *ngIf="dialogRef" class="fa fa-compress" aria-hidden="true" (click)="dialogRef.close()"></i>
+            </mat-card-header>
+            <mat-card-content>
+                <app-ngram-distribution [texts]="sampleTexts"></app-ngram-distribution>
+            </mat-card-content>
+        </ng-template>
     </mat-card>
 </div>

--- a/ngapp/src/app/teacher-components/stats-dashboard/stats-dashboard.component.ts
+++ b/ngapp/src/app/teacher-components/stats-dashboard/stats-dashboard.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { NgramDistributionComponent } from 'app/story-stats/ngram-distribution/ngram-distribution/ngram-distribution.component';
 
 @Component({
   selector: 'app-stats-dashboard',
@@ -7,36 +9,53 @@ import { Component, OnInit } from '@angular/core';
 })
 export class StatsDashboardComponent implements OnInit {
 
-  constructor() { }
+  constructor(
+    public dialog: MatDialog
+  ) { }
 
   ngOnInit(): void {}
+
+  dialogRef: MatDialogRef<unknown>;
 
   sampleTexts = [
     'Hello there. The cat sat on the mat.',
     'The dog sat on the frog.',
     'The frog sat on the dog'
   ];
-  
+
+  // @ViewChild(NgramDistributionComponent)
+  // ngramDistributionComponent: NgramDistributionComponent;
+
+  openModal(templateRef: TemplateRef<unknown>) {
+    this.dialogRef = this.dialog.open(templateRef, {
+         width: '60%',
+    });
+
+    this.dialogRef.afterClosed().subscribe(result => {
+        this.dialogRef = undefined;
+    });
+  }
 
   toggleFullscreen(event: MouseEvent): void {
-    // Make the card fullscreen via CSS
-    const targetElem = event.target as HTMLElement;
-    const cardElem = targetElem.closest('.stats-card') as HTMLElement; // They may have clicked on a descendent of the mat card
-    const canvasElem = cardElem.querySelector('canvas');
-    const fullscreenIcon = targetElem.closest('i') as HTMLElement;
-    if (cardElem.classList.contains('stats-card-fullscreen')) {
-      cardElem.classList.remove('stats-card-fullscreen');
-      canvasElem.style.cssText = `width: 400px; height: 200px;`;
-      fullscreenIcon.classList.remove('fa-compress');
-      fullscreenIcon.classList.add('fa-expand');
-    } else {
-      cardElem.classList.add('stats-card-fullscreen');
-      canvasElem.width = cardElem.offsetWidth;
-      canvasElem.height = 400;
-      canvasElem.style.cssText = `width: ${cardElem.offsetWidth}px;`;
-      fullscreenIcon.classList.remove('fa-expand');
-      fullscreenIcon.classList.add('fa-compress');
-    }
+
+    // // Make the card fullscreen via CSS
+    // const targetElem = event.target as HTMLElement;
+    // const cardElem = targetElem.closest('.stats-card') as HTMLElement; // They may have clicked on a descendent of the mat card
+    // const canvasElem = cardElem.querySelector('canvas');
+    // const fullscreenIcon = targetElem.closest('i') as HTMLElement;
+    // if (cardElem.classList.contains('stats-card-fullscreen')) {
+    //   cardElem.classList.remove('stats-card-fullscreen');
+    //   canvasElem.style.cssText = `width: 400px; height: 200px;`;
+    //   fullscreenIcon.classList.remove('fa-compress');
+    //   fullscreenIcon.classList.add('fa-expand');
+    // } else {
+    //   cardElem.classList.add('stats-card-fullscreen');
+    //   canvasElem.width = cardElem.offsetWidth;
+    //   canvasElem.height = 400;
+    //   canvasElem.style.cssText = `width: ${cardElem.offsetWidth}px;`;
+    //   fullscreenIcon.classList.remove('fa-expand');
+    //   fullscreenIcon.classList.add('fa-compress');
+    // }
   }
 
 }

--- a/ngapp/src/app/teacher-components/stats-dashboard/stats-dashboard.component.ts
+++ b/ngapp/src/app/teacher-components/stats-dashboard/stats-dashboard.component.ts
@@ -23,39 +23,14 @@ export class StatsDashboardComponent implements OnInit {
     'The frog sat on the dog'
   ];
 
-  // @ViewChild(NgramDistributionComponent)
-  // ngramDistributionComponent: NgramDistributionComponent;
-
   openModal(templateRef: TemplateRef<unknown>) {
     this.dialogRef = this.dialog.open(templateRef, {
          width: '60%',
     });
 
-    this.dialogRef.afterClosed().subscribe(result => {
+    this.dialogRef.afterClosed().subscribe(_ => {
         this.dialogRef = undefined;
     });
-  }
-
-  toggleFullscreen(event: MouseEvent): void {
-
-    // // Make the card fullscreen via CSS
-    // const targetElem = event.target as HTMLElement;
-    // const cardElem = targetElem.closest('.stats-card') as HTMLElement; // They may have clicked on a descendent of the mat card
-    // const canvasElem = cardElem.querySelector('canvas');
-    // const fullscreenIcon = targetElem.closest('i') as HTMLElement;
-    // if (cardElem.classList.contains('stats-card-fullscreen')) {
-    //   cardElem.classList.remove('stats-card-fullscreen');
-    //   canvasElem.style.cssText = `width: 400px; height: 200px;`;
-    //   fullscreenIcon.classList.remove('fa-compress');
-    //   fullscreenIcon.classList.add('fa-expand');
-    // } else {
-    //   cardElem.classList.add('stats-card-fullscreen');
-    //   canvasElem.width = cardElem.offsetWidth;
-    //   canvasElem.height = 400;
-    //   canvasElem.style.cssText = `width: ${cardElem.offsetWidth}px;`;
-    //   fullscreenIcon.classList.remove('fa-expand');
-    //   fullscreenIcon.classList.add('fa-compress');
-    // }
   }
 
 }


### PR DESCRIPTION
Here's how it looks:

https://user-images.githubusercontent.com/34962541/194885870-ad0c9c44-4416-4fbb-a6f2-0efe7e638193.mov

**Note:** one potential issue is that it's not maintaining the card's state when we toggle between small / full-screen. i.e. it 'restarts' the component each time we toggle. A solution shouldn't be too complicated, storing the chart states in the `stats-dashboard` component using `@Input` and `@Output`s in each chart component to update the global states. We may not need to solve this though if the charts aren't too complex: if there isn't much configuration happening within the chart components the user probably wouldn't mind.