### PR TITLE
Only show 'recordings' button if text not empty

### DIFF
--- a/ngapp/src/app/student-components/dashboard/dashboard.component.html
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.html
@@ -158,7 +158,7 @@
       -->
 
       <!-- RECORDINGS -->
-      <div *ngIf="showOptions" class="optionsBtn optionsPopupBtn"
+      <div *ngIf="showOptions" [hidden]="story.text.length === 0" class="optionsBtn optionsPopupBtn"
         (click)="this.dontToggle=true; goToRecording()">
         {{ts.l.recordings}}
         <i class="fas fa-microphone optionsBtnIcon"></i>


### PR DESCRIPTION
This will help avoid empty recordings boxes such as the following:

<img width="1280" alt="Screenshot 2022-10-11 at 16 27 04" src="https://user-images.githubusercontent.com/34962541/195139921-aef88107-80ad-440e-8d6e-812d1aadaafa.png">

The user can always see the latest version of their story archiving the current recordings. Ideally we would prompt the user to archive when the recordings show an outdated version of their story, but I think in order to do this we would need to save some copy of the story text with the recordings, rather than just the ID, which feels slightly overkill if we plan to redesign this anyway at some point.