### PR TITLE
Deprecate querying stories by author

### DIFF
--- a/api/routes/story.route.js
+++ b/api/routes/story.route.js
@@ -59,8 +59,8 @@ let storyRoutes;
 })();
 
 // Get stories by a given author after a certain date from DB
-storyRoutes.route('/getStoriesForClassroom/:author/:date').get(function (req, res) {
-  Story.find({"author": req.params.author, date: {$gte: req.params.date}}, function (err, stories) {
+storyRoutes.route('/getStoriesForClassroom/:owner/:date').get(function (req, res) {
+  Story.find({"owner": req.params.owner, date: {$gte: req.params.date}}, function (err, stories) {
     if(err) {
       console.log(err);
       res.json(err)

--- a/ngapp/src/app/story.service.ts
+++ b/ngapp/src/app/story.service.ts
@@ -57,8 +57,8 @@ export class StoryService {
     return this.http.get(this.baseUrl + author);
   }
 
-  getStoriesByOwner(owner: string) : Observable<any>  {
-    return this.http.get(this.baseUrl + 'owner/' + owner);
+  getStoriesByOwner(owner: string) : Observable<Story[]>  {
+    return this.http.get<Story[]>(this.baseUrl + 'owner/' + owner);
   }
 
   getStory(id: string) : Observable<any> {
@@ -73,8 +73,7 @@ export class StoryService {
         subscriber.complete();
       });
     }
-    const author = userDetails.username;
-    return this.http.get<Story[]>(this.baseUrl + author);
+    return this.getStoriesByOwner(userDetails._id);
   }
 
   updateStoryTitleAndDialect(story: Story): Observable<any> {

--- a/ngapp/src/app/story.service.ts
+++ b/ngapp/src/app/story.service.ts
@@ -80,8 +80,8 @@ export class StoryService {
     return this.http.post(this.baseUrl + 'update/' + story._id, story);
   }
   
-  getStoriesForClassroom(author: string, date): Observable<any> {
-    return this.http.get(this.baseUrl + "getStoriesForClassroom/" + author + "/" + date);
+  getStoriesForClassroom(owner: string, date): Observable<any> {
+    return this.http.get(this.baseUrl + "getStoriesForClassroom/" + owner + "/" + date);
   }
 
   updateStory(updateData: any, id: string): Observable<any> {

--- a/ngapp/src/app/teacher-components/teacher-classroom/teacher-classroom.component.ts
+++ b/ngapp/src/app/teacher-components/teacher-classroom/teacher-classroom.component.ts
@@ -88,7 +88,7 @@ export class TeacherClassroomComponent implements OnInit {
         this.students.sort((a, b) => a.username.toLowerCase().localeCompare(b.username.toLowerCase()));
         this.studentIds.push(res._id);
         if(this.classroom.date) {
-          this.storyService.getStoriesForClassroom(res.username, this.classroom.date).subscribe( (stories) => {
+          this.storyService.getStoriesForClassroom(res._id, this.classroom.date).subscribe( (stories) => {
             let count = Object.keys(stories).length;
             this.numOfStories.set(res.username, count);
           });

--- a/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.ts
+++ b/ngapp/src/app/teacher-components/teacher-student/teacher-student.component.ts
@@ -6,6 +6,7 @@ import { StoryService } from '../../story.service';
 import { TranslationService } from '../../translation.service';
 import { ClassroomService } from '../../classroom.service';
 import config from 'abairconfig';
+import { User } from 'app/user';
 
 @Component({
   selector: 'app-teacher-student',
@@ -21,7 +22,7 @@ export class TeacherStudentComponent implements OnInit {
     public ts : TranslationService,
     private classroomService: ClassroomService) { }
 
-    student: any;
+    student: User;
     stories: Story[];
     storiesWithoutFeedback: Story[] = [];
     userId: string;
@@ -41,7 +42,7 @@ export class TeacherStudentComponent implements OnInit {
               }
           }
         ).subscribe(
-        (res) => {
+        (res: User) => {
           this.userId = params['id'].toString();
           this.student = res;
           this.setClassroomId();
@@ -62,7 +63,7 @@ export class TeacherStudentComponent implements OnInit {
       this.classroomService.getClassroomOfStudent(this.userId).subscribe((res) => {
         this.classroomId = res._id;
         if(res.date) {
-          this.storyService.getStoriesForClassroom(this.student.username, res.date).subscribe((data: Story[]) => {
+          this.storyService.getStoriesForClassroom(this.student._id, res.date).subscribe((data: Story[]) => {
             this.stories = data, this.filterFeedback(data);
           });
         }


### PR DESCRIPTION
- Recording story ownership via username doesn't allow for username changes, so instead we prefer the `owner` property, linking to the owner's `_id`.
- This PR updates queries using author to instead us owner.
- Also, every story with an owner now has an associated owner value. On the DB there are 123 stories without the owner property, but the corresponding authors no longer exist (i.e. they have deleted their accounts). Apart from a couple of authors with special characters (like `ó`) that aren't found by `User.find()`.

**Quick note on Mongo reliability, while you're here:**
- It turns out that get-story-by-author queries were the most common kind of query made on the database in the last few months:
<img width="795" alt="image" src="https://user-images.githubusercontent.com/34962541/196476529-4ea9b254-fc1a-4c66-8b07-7d7b2da1a5c8.png">

- This isn't great, because we don't have an index on the author property, meaning every time a query like this is run, the entire story collection is loaded into memory.
- So the plan is to deploy this change and then put an index on the owner property to (hopefully) make our queries more memory-efficient.
