### PR TITLE
Ensure story.text is not null before checking length

### DIFF
--- a/ngapp/src/app/student-components/dashboard/dashboard.component.html
+++ b/ngapp/src/app/student-components/dashboard/dashboard.component.html
@@ -158,7 +158,7 @@
       -->
 
       <!-- RECORDINGS -->
-      <div *ngIf="showOptions" [hidden]="story.text.length === 0" class="optionsBtn optionsPopupBtn"
+      <div *ngIf="showOptions" [hidden]="story.text && story.text.length === 0" class="optionsBtn optionsPopupBtn"
         (click)="this.dontToggle=true; goToRecording()">
         {{ts.l.recordings}}
         <i class="fas fa-microphone optionsBtnIcon"></i>


### PR DESCRIPTION
I think this fixes #281, the problem being in this line:
```
<div *ngIf="showOptions" --> [hidden]="story.text.length === 0" <-- class="optionsBtn optionsPopupBtn" ...
```
Where it was trying to access story.text.length before the story had loaded